### PR TITLE
Feat/message id#54

### DIFF
--- a/src/mailprocessing/mail_receiver.rs
+++ b/src/mailprocessing/mail_receiver.rs
@@ -183,13 +183,13 @@ where
                 // TODO: find a way to handle SystemTime failure.
                 message_id: format!(
                     "{}{}{}",
-                    now.elapsed()
+                    now.duration_since(std::time::SystemTime::UNIX_EPOCH)
                         .unwrap_or(std::time::Duration::ZERO)
                         .as_micros(),
                     self.mail
                         .connection
                         .timestamp
-                        .elapsed()
+                        .duration_since(std::time::SystemTime::UNIX_EPOCH)
                         .unwrap_or(std::time::Duration::ZERO)
                         .as_millis(),
                     std::process::id()

--- a/src/mailprocessing/mail_receiver.rs
+++ b/src/mailprocessing/mail_receiver.rs
@@ -175,10 +175,25 @@ where
             self.mail.envelop.rcpt.clear();
             self.rule_engine.reset();
 
+            let now = std::time::SystemTime::now();
+
             // generating email metadata.
             self.mail.metadata = Some(MessageMetadata {
-                timestamp: std::time::SystemTime::now(),
-                message_id: "".to_string(),
+                timestamp: now,
+                // TODO: find a way to handle SystemTime failure.
+                message_id: format!(
+                    "{}{}{}",
+                    now.elapsed()
+                        .unwrap_or(std::time::Duration::ZERO)
+                        .as_micros(),
+                    self.mail
+                        .connection
+                        .timestamp
+                        .elapsed()
+                        .unwrap_or(std::time::Duration::ZERO)
+                        .as_millis(),
+                    std::process::id()
+                ),
                 retry: 0,
             });
 

--- a/src/mailprocessing/mail_receiver.rs
+++ b/src/mailprocessing/mail_receiver.rs
@@ -20,7 +20,7 @@ use super::io_service::{IoService, ReadError};
 use crate::config::log::{RECEIVER, RULES};
 use crate::config::server_config::{ServerConfig, TlsSecurityLevel};
 use crate::model::envelop::Envelop;
-use crate::model::mail::{ConnectionData, MailContext};
+use crate::model::mail::{ConnectionData, MailContext, MessageMetadata};
 use crate::resolver::DataEndResolver;
 use crate::rules::address::Address;
 use crate::rules::rule_engine::{RuleEngine, Status};
@@ -143,7 +143,7 @@ where
                 },
                 envelop: Envelop::default(),
                 body: String::with_capacity(MAIL_CAPACITY),
-                timestamp: None,
+                metadata: None,
             },
             tls_config,
             is_secured: false,
@@ -172,14 +172,20 @@ where
     fn set_mail_from(&mut self, mail_from: String) {
         if let Ok(mail_from) = Address::new(&mail_from) {
             self.mail.envelop.mail_from = mail_from;
-            self.mail.timestamp = Some(std::time::SystemTime::now());
             self.mail.envelop.rcpt.clear();
             self.rule_engine.reset();
+
+            // generating email metadata.
+            self.mail.metadata = Some(MessageMetadata {
+                timestamp: std::time::SystemTime::now(),
+                message_id: "".to_string(),
+                retry: 0,
+            });
 
             self.rule_engine
                 .add_data("mail", self.mail.envelop.mail_from.clone());
             self.rule_engine
-                .add_data("mail_timestamp", self.mail.timestamp);
+                .add_data("metadata", self.mail.metadata.clone());
         }
     }
 
@@ -358,19 +364,7 @@ where
                 };
 
                 // executing all registered extensive operations.
-                if let Err(error) = self.rule_engine.execute_operation_queue(
-                    &self.mail,
-                    &format!(
-                        "{}_{:?}",
-                        self.mail
-                            .timestamp
-                            .unwrap()
-                            .duration_since(std::time::SystemTime::UNIX_EPOCH)
-                            .unwrap()
-                            .as_millis(),
-                        std::thread::current().id()
-                    ),
-                ) {
+                if let Err(error) = self.rule_engine.execute_operation_queue(&self.mail) {
                     log::error!(
                         target: RULES,
                         "failed to empty the operation queue: '{}'",

--- a/src/mailprocessing/mail_receiver.rs
+++ b/src/mailprocessing/mail_receiver.rs
@@ -346,11 +346,9 @@ where
             (StateSMTP::Data, Event::DataEnd) => {
                 self.rule_engine.add_data("data", self.mail.body.clone());
 
-                let status = self.rule_engine.run_when("preq");
-
-                let result = match status {
+                let result = match self.rule_engine.run_when("preq") {
                     Status::Block => return (Some(StateSMTP::Stop), Some(SMTPReplyCode::Code554)),
-                    _ => self.process_rules_status(
+                    status => self.process_rules_status(
                         status,
                         Some(StateSMTP::MailFrom),
                         Some(SMTPReplyCode::Code250),

--- a/src/mailprocessing/mail_receiver.rs
+++ b/src/mailprocessing/mail_receiver.rs
@@ -35,7 +35,7 @@ enum ProcessedEvent {
     Nothing,
     Reply(SMTPReplyCode),
     ReplyChangeState(StateSMTP, SMTPReplyCode),
-    TransactionCompleted(MailContext),
+    TransactionCompleted(Box<MailContext>),
 }
 
 pub struct MailReceiver<'a, R>
@@ -361,7 +361,7 @@ where
 
                     std::mem::swap(&mut self.mail, &mut output);
 
-                    ProcessedEvent::TransactionCompleted(output)
+                    ProcessedEvent::TransactionCompleted(Box::new(output))
                 } else {
                     ProcessedEvent::ReplyChangeState(StateSMTP::MailFrom, SMTPReplyCode::Code554)
                 }
@@ -501,7 +501,7 @@ where
                 ProcessedEvent::Reply(reply_to_send) => {
                     self.send_reply(io, reply_to_send).map(|_| None)
                 }
-                ProcessedEvent::TransactionCompleted(mail) => Ok(Some(mail)),
+                ProcessedEvent::TransactionCompleted(mail) => Ok(Some(*mail)),
                 ProcessedEvent::Nothing => Ok(None),
                 ProcessedEvent::ReplyChangeState(_, _) => unreachable!(),
             },

--- a/src/model/mail.rs
+++ b/src/model/mail.rs
@@ -27,6 +27,7 @@ pub struct MessageMetadata {
     /// instant when the last "MAIL FROM" has been received.
     pub timestamp: std::time::SystemTime,
     /// unique id generated when the "MAIL FROM" has been received.
+    /// format: {mail timestamp}{connection timestamp}{process id (on reboot)}
     pub message_id: String,
     /// number of times the mta tried to send the email.
     pub retry: usize,

--- a/src/model/mail.rs
+++ b/src/model/mail.rs
@@ -22,7 +22,7 @@ pub struct ConnectionData {
     pub timestamp: std::time::SystemTime,
 }
 
-#[derive(serde::Deserialize, serde::Serialize, Clone)]
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
 pub struct MessageMetadata {
     /// instant when the last "MAIL FROM" has been received.
     pub timestamp: std::time::SystemTime,

--- a/src/model/mail.rs
+++ b/src/model/mail.rs
@@ -22,11 +22,30 @@ pub struct ConnectionData {
     pub timestamp: std::time::SystemTime,
 }
 
+#[derive(serde::Deserialize, serde::Serialize, Clone)]
+pub struct MessageMetadata {
+    /// instant when the last "MAIL FROM" has been received.
+    pub timestamp: std::time::SystemTime,
+    /// unique id generated when the "MAIL FROM" has been received.
+    pub message_id: String,
+    /// number of times the mta tried to send the email.
+    pub retry: usize,
+}
+
+impl Default for MessageMetadata {
+    fn default() -> Self {
+        Self {
+            timestamp: std::time::SystemTime::now(),
+            message_id: Default::default(),
+            retry: Default::default(),
+        }
+    }
+}
+
 #[derive(serde::Deserialize, serde::Serialize)]
 pub struct MailContext {
     pub connection: ConnectionData,
     pub envelop: super::envelop::Envelop,
     pub body: String,
-    // instant when the last "MAIL FROM" has been received
-    pub timestamp: Option<std::time::SystemTime>,
+    pub metadata: Option<MessageMetadata>,
 }

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -70,16 +70,6 @@ impl MailDirResolver {
             static ref DELIVERIES: std::sync::Mutex<Wrapper> = std::sync::Mutex::new(Wrapper{0:0});
         }
 
-        let mut delivery_count = match DELIVERIES.lock() {
-            Ok(count) => count,
-            Err(_) => {
-                return Err(std::io::Error::new(
-                    std::io::ErrorKind::Other,
-                    "delivery mutex poisoned.",
-                ))
-            }
-        };
-
         match crate::rules::rule_engine::get_user_by_name(rcpt.local_part()) {
             Some(user) => {
                 // getting user's home directory using getpwuid.
@@ -116,6 +106,16 @@ impl MailDirResolver {
                         &user,
                     )?;
                 }
+
+                let mut delivery_count = match DELIVERIES.lock() {
+                    Ok(count) => count,
+                    Err(_) => {
+                        return Err(std::io::Error::new(
+                            std::io::ErrorKind::Other,
+                            "delivery mutex poisoned.",
+                        ))
+                    }
+                };
 
                 // NOTE: see https://en.wikipedia.org/wiki/Maildir
                 maildir.push(format!(

--- a/src/rules/actions.rs
+++ b/src/rules/actions.rs
@@ -42,7 +42,7 @@ use super::address::Address;
 pub(super) mod vsl {
     use std::{collections::HashSet, net::SocketAddr};
 
-    use crate::{config::log::RULES, rules::address::Address};
+    use crate::{config::log::RULES, model::mail::MessageMetadata, rules::address::Address};
 
     /// enqueue a block operation on the queue.
     pub fn op_block(queue: &mut OperationQueue, path: &str) {
@@ -173,7 +173,7 @@ pub(super) mod vsl {
         rcpt: HashSet<Address>,
         data: &str,
         connection_timestamp: std::time::SystemTime,
-        mail_timestamp: Option<std::time::SystemTime>,
+        metadata: Option<MessageMetadata>,
         path: &str,
     ) -> Result<(), Box<EvalAltResult>> {
         if let Err(error) = std::fs::create_dir_all(path) {
@@ -205,7 +205,7 @@ pub(super) mod vsl {
                 timestamp: connection_timestamp,
             },
 
-            timestamp: mail_timestamp,
+            metadata,
         };
 
         std::io::Write::write_all(&mut file, serde_json::to_string(&ctx).unwrap().as_bytes())

--- a/src/rules/currying.rhai
+++ b/src/rules/currying.rhai
@@ -95,7 +95,7 @@ let vsl = #{
 
     // write the current evenlop and mail content to a file in json format.
     DUMP: |path| {
-        __DUMP(connect, port, helo, mail, rcpts, data, connection_timestamp, mail_timestamp, path);
+        __DUMP(connect, port, helo, mail, rcpts, data, connection_timestamp, metadata, path);
     },
 
     // write a mail to the an user defiened quarantine folder.

--- a/src/rules/rule_engine.rs
+++ b/src/rules/rule_engine.rs
@@ -287,10 +287,10 @@ impl<U: Users> RhaiEngine<U> {
             }
         })
         .register_get("retry", |metadata: &mut Option<MessageMetadata>| {
-            match metadata {
+            (match metadata {
                 Some(metadata) => metadata.retry,
                 None => 0,
-            }
+            }) as u64
         })
         .register_fn("to_string", |metadata: &mut Option<MessageMetadata>| match metadata {
             Some(metadata) => format!("{:?}", metadata),
@@ -305,12 +305,12 @@ impl<U: Users> RhaiEngine<U> {
         .register_type::<OperationQueue>()
         .register_type::<std::time::SystemTime>()
         .register_fn("to_string", |time: &mut std::time::SystemTime| format!("{}",
-            time.elapsed()
+            time.duration_since(std::time::SystemTime::UNIX_EPOCH)
                 .unwrap_or(std::time::Duration::ZERO)
                 .as_secs()
         ))
         .register_fn("to_debug", |time: &mut std::time::SystemTime| format!("{:?}",
-            time.elapsed()
+            time.duration_since(std::time::SystemTime::UNIX_EPOCH)
             .unwrap_or(std::time::Duration::ZERO)
             .as_secs()
         ))

--- a/src/rules/rule_engine.rs
+++ b/src/rules/rule_engine.rs
@@ -292,6 +292,14 @@ impl<U: Users> RhaiEngine<U> {
                 None => 0,
             }
         })
+        .register_fn("to_string", |metadata: &mut Option<MessageMetadata>| match metadata {
+            Some(metadata) => format!("{:?}", metadata),
+            None => "".to_string(),
+        })
+        .register_fn("to_debug", |metadata: &mut Option<MessageMetadata>| match metadata {
+            Some(metadata) => format!("{:?}", metadata),
+            None => "".to_string(),
+        })
 
         // the operation queue is used to defer actions.
         .register_type::<OperationQueue>()

--- a/src/rules/rule_engine.rs
+++ b/src/rules/rule_engine.rs
@@ -16,7 +16,7 @@
  **/
 use crate::config::log::RULES;
 use crate::model::envelop::Envelop;
-use crate::model::mail::MailContext;
+use crate::model::mail::{MailContext, MessageMetadata};
 use crate::rules::address::Address;
 use crate::rules::obj::Object;
 use crate::rules::operation_queue::{Operation, OperationQueue};
@@ -67,6 +67,7 @@ impl<'a> RuleEngine<'a> {
     pub(crate) fn new(config: &crate::config::server_config::ServerConfig) -> Self {
         let mut scope = Scope::new();
         scope
+            // stage variables.
             .push("connect", IpAddr::V4(Ipv4Addr::UNSPECIFIED))
             .push("port", 0)
             .push("helo", "")
@@ -74,15 +75,17 @@ impl<'a> RuleEngine<'a> {
             .push("rcpt", Address::default())
             .push("rcpts", HashSet::<Address>::new())
             .push("data", "")
+            // rule engine's internals.
             .push("__OPERATION_QUEUE", OperationQueue::default())
             .push("__stage", "")
             .push("__rules", Array::new())
-            .push("__init", true)
+            .push("__init", false)
+            // useful data.
             .push("date", "")
             .push("time", "")
-            .push("msg_id", "")
             .push("connection_timestamp", std::time::SystemTime::now())
-            .push("mail_timestamp", None::<std::time::SystemTime>)
+            .push("metadata", None::<MessageMetadata>)
+            // configuration variables.
             .push("addr", config.server.addr)
             .push("logs_file", config.log.file.clone())
             .push("spool_dir", config.smtp.spool_dir.clone());
@@ -169,7 +172,6 @@ impl<'a> RuleEngine<'a> {
     pub(crate) fn execute_operation_queue(
         &mut self,
         ctx: &MailContext,
-        msg_id: &str,
     ) -> Result<(), Box<dyn Error>> {
         for op in self
             .scope
@@ -185,7 +187,7 @@ impl<'a> RuleEngine<'a> {
                     let mut path = std::path::PathBuf::from_str(&path)?;
                     std::fs::create_dir_all(&path)?;
 
-                    path.push(msg_id);
+                    path.push(&ctx.metadata.as_ref().unwrap().message_id);
                     path.set_extension("json");
 
                     let mut file = std::fs::OpenOptions::new()
@@ -211,11 +213,11 @@ impl<'a> RuleEngine<'a> {
         })
     }
 
-    /// clears mail_from, mail_timestamp, rcpt, rcpts & data values from the scope.
+    /// clears mail_from, metadata, rcpt, rcpts & data values from the scope.
     pub(crate) fn reset(&mut self) {
         self.scope
             .push("mail", Address::default())
-            .push("mail_timestamp", None::<std::time::SystemTime>)
+            .push("metadata", None::<MessageMetadata>)
             .push("rcpt", Address::default())
             .push("rcpts", HashSet::<Address>::new())
             .push("data", "");
@@ -671,7 +673,7 @@ lazy_static::lazy_static! {
         .push("date", "")
         .push("time", "")
         .push("connection_timestamp", std::time::SystemTime::now())
-        .push("mail_timestamp", None::<std::time::SystemTime>)
+        .push("metadata", None::<MessageMetadata>)
 
         // configuration variables.
         .push("addr", Vec::<String>::new())

--- a/tests/integration/protocol/clair.rs
+++ b/tests/integration/protocol/clair.rs
@@ -32,6 +32,7 @@ mod tests {
                     HashSet::from([Address::new("aa@bb").unwrap()])
                 );
                 assert_eq!(ctx.body, "");
+                assert!(ctx.metadata.is_some());
 
                 Ok(SMTPReplyCode::Code250)
             }
@@ -380,6 +381,7 @@ mod tests {
                             HashSet::from([Address::new("aa@bb").unwrap()])
                         );
                         assert_eq!(ctx.body, "mail one\n");
+                        assert!(ctx.metadata.is_some());
                     }
                     1 => {
                         assert_eq!(ctx.envelop.helo, "foobar");
@@ -389,6 +391,7 @@ mod tests {
                             HashSet::from([Address::new("aa2@bb").unwrap()])
                         );
                         assert_eq!(ctx.body, "mail two\n");
+                        assert!(ctx.metadata.is_some());
                     }
                     _ => panic!(),
                 }


### PR DESCRIPTION
This pr adds the `MessageMetadata` container to the JSON `MailContext` structure.

```rust
pub struct MessageMetadata {
    pub timestamp: std::time::SystemTime,
    pub message_id: String,
    pub retry: usize,
}
```

This structure contains the following fields:
- `timestamp` the timestamp of the first `MAIL FROM` command.
- `message_id` the id of the email generated when the `MAIL FROM` command is received.
- `retry`  number of times the server tried to send the email to a client / mta.

the message id is formatted this way:
``{mail timestamp}{connection timestamp}{process id}``

> i.e. 1641317917759096164131791771147547
>  1641317917759096 (mail μs) 1641317917711 (connection ms) 47547 (process id)

**Documentation changes**

in rhai's content, the following variables are deleted:
- `mail_timestamp`

the following variables have been added:
- `metadata`: get metadata of the email. (rust type is `Option<MessageMetadata>`)
  - methods:
    - `timestamp` getter, get the timestamp of the email (if None, return `SystemTime::now()`)
    - `message_id` getter, get the message id of the email (if None, return an empty string)
    - `retry` getter, get the number of times the server tried to send the email (if None, return 0)

example:

```rust
rule preq "metadata" #{
  condition: || true,
  on_success: || {
    vsl.LOG_OUT(`all: ${metadata}`);
    vsl.LOG_OUT(`timestamp: ${metadata.timestamp}`);
    vsl.LOG_OUT(`id: ${metadata.message_id}`);
    vsl.LOG_OUT(`retries: ${metadata.retry}`);
    vsl.CONTINUE()
  },
};
```

the `metadata` variable is injected in the `mail` stage.

closes #54 