### PR TITLE
Feat/deliver process#55

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ iprange = "0.6.6"
 ipnet = "2.3.1"
 chrono = "0.4.19"
 
-rhai = { version = "1.3.0", features = ["unchecked", "sync"] }
+rhai = { version = "1.4.0", features = ["unchecked", "sync"] }
 
 # the 0.10 release is more stable than the 0.9 and enable async support.
 lettre = "0.10.0-rc.4"

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -6,4 +6,5 @@ pub mod log {
     pub const RECEIVER: &str = "receiver";
     pub const RESOLVER: &str = "resolver";
     pub const RULES: &str = "rules";
+    pub const DELIVER: &str = "deliver";
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,7 +60,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         return Err(error);
     }
 
-    let (s, r) = crossbeam_channel::bounded::<String>(1);
+    let (s, r) = crossbeam_channel::bounded::<String>(0);
 
     let mut deliver_queue = <std::path::PathBuf as std::str::FromStr>::from_str(&format!(
         "{}/deliver/",

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,3 @@
-use vsmtp::config::log::DELIVER;
 /**
  * vSMTP mail transfer agent
  * Copyright (C) 2021 viridIT SAS
@@ -14,7 +13,8 @@ use vsmtp::config::log::DELIVER;
  * You should have received a copy of the GNU General Public License along with
  * this program. If not, see https://www.gnu.org/licenses/.
  *
-**/
+ **/
+use vsmtp::config::log_channel::DELIVER;
 use vsmtp::config::server_config::ServerConfig;
 use vsmtp::resolver::maildir_resolver::MailDirResolver;
 use vsmtp::resolver::DataEndResolver;
@@ -31,7 +31,7 @@ struct Args {
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args = <Args as clap::StructOpt>::parse();
 
-    log::warn!("Loading with configuration: \"{:?}\"", args.config);
+    println!("Loading with configuration: \"{:?}\"", args.config);
 
     let config: ServerConfig =
         toml::from_str(&std::fs::read_to_string(args.config).expect("cannot read file"))
@@ -66,7 +66,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         "{}/deliver/tmp",
         config.smtp.spool_dir
     ))
-    // unfailable.
+    // infallible.
     .unwrap();
 
     if !deliver_queue.exists() {
@@ -102,7 +102,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
                 log::debug!(
                     target: DELIVER,
-                    "message '{}' sent successfuly.",
+                    "message '{}' sent successfully.",
                     message_id
                 );
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,7 +63,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let (s, r) = crossbeam_channel::bounded::<String>(0);
 
     let mut deliver_queue = <std::path::PathBuf as std::str::FromStr>::from_str(&format!(
-        "{}/deliver/",
+        "{}/deliver/tmp",
         config.smtp.spool_dir
     ))
     // unfailable.
@@ -80,10 +80,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         // TODO: check config / rule engine for right resolver.
         // TODO: empty queue when booting.
         let mut resolver = MailDirResolver::default();
-        deliver_queue.push("tmp");
 
         loop {
-            if let Ok(message_id) = r.try_recv() {
+            // TODO: handle errors.
+            if let Ok(message_id) = r.recv() {
                 log::debug!(
                     target: DELIVER,
                     "delivery process received a new message id: {}",

--- a/src/resolver/maildir_resolver.rs
+++ b/src/resolver/maildir_resolver.rs
@@ -179,13 +179,8 @@ impl DataEndResolver for MailDirResolver {
                         "Couldn't write email to inbox: {:?}",
                         error
                     );
-                } else {
-                    todo!();
-                    // self.sender
-                    //     .send(mail.metadata.as_ref().unwrap().message_id.clone())
-                    //     .map_err(|e| {
-                    //         std::io::Error::new(std::io::ErrorKind::Other, format!("{}", e))
-                    //     })?;
+
+                    return Err(error);
                 }
             } else {
                 log::trace!(

--- a/src/resolver/maildir_resolver.rs
+++ b/src/resolver/maildir_resolver.rs
@@ -42,15 +42,8 @@ fn chown_file(path: &std::path::Path, user: &users::User) -> std::io::Result<()>
     Ok(())
 }
 
-pub struct MailDirResolver {
-    sender: crossbeam_channel::Sender<String>,
-}
-
-impl MailDirResolver {
-    pub fn new(sender: crossbeam_channel::Sender<String>) -> Self {
-        Self { sender }
-    }
-}
+#[derive(Default)]
+pub struct MailDirResolver;
 
 impl MailDirResolver {
     // getting user's home directory using getpwuid.
@@ -187,11 +180,12 @@ impl DataEndResolver for MailDirResolver {
                         error
                     );
                 } else {
-                    self.sender
-                        .send(mail.metadata.as_ref().unwrap().message_id.clone())
-                        .map_err(|e| {
-                            std::io::Error::new(std::io::ErrorKind::Other, format!("{}", e))
-                        })?;
+                    todo!();
+                    // self.sender
+                    //     .send(mail.metadata.as_ref().unwrap().message_id.clone())
+                    //     .map_err(|e| {
+                    //         std::io::Error::new(std::io::ErrorKind::Other, format!("{}", e))
+                    //     })?;
                 }
             } else {
                 log::trace!(

--- a/src/rules/rule_engine.rs
+++ b/src/rules/rule_engine.rs
@@ -429,7 +429,7 @@ impl<U: Users> RhaiEngine<U> {
             },
             true,
             move |context, input| {
-                let when = input[0].get_variable_name().unwrap().to_string();
+                let when = input[0].get_string_value().unwrap().to_string();
                 let name = input[1].get_literal_value::<ImmutableString>().unwrap();
                 let map = &input[2];
 
@@ -502,7 +502,7 @@ impl<U: Users> RhaiEngine<U> {
             },
             true,
             move |context, input| {
-                let var_type = input[0].get_variable_name().unwrap().to_string();
+                let var_type = input[0].get_string_value().unwrap().to_string();
                 let var_name: String;
 
                 // FIXME: refactor this expression.
@@ -511,7 +511,7 @@ impl<U: Users> RhaiEngine<U> {
                 let object = match var_type.as_str() {
                     "file" => {
 
-                        let content_type = input[2].get_variable_name().unwrap();
+                        let content_type = input[2].get_string_value().unwrap();
                         var_name = input[3].get_literal_value::<ImmutableString>().unwrap().to_string();
                         let object = context.eval_expression_tree(&input[4])?;
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -17,6 +17,7 @@
 use crate::{
     config::{
         get_logger_config,
+        log_channel::RECEIVER,
         server_config::{ServerConfig, TlsSecurityLevel},
     },
     connection::Connection,
@@ -242,7 +243,7 @@ impl ServerVSMTP {
     }
 }
 
-/// indentifiers for all mail queues.
+/// identifiers for all mail queues.
 #[allow(unused)]
 enum Queue {
     Deliver,
@@ -289,7 +290,7 @@ impl DataEndResolver for DeliverQueueResolver {
 
         log::trace!(
             target: RECEIVER,
-            "mail {} successfuly written to deliver queue",
+            "mail {} successfully written to deliver queue",
             message_id
         );
 
@@ -318,7 +319,7 @@ fn write_to_queue(
         queue.as_str(),
         &message_id
     ))
-    // unfailable.
+    // infallible.
     .unwrap();
 
     // TODO: should loop if a file name is conflicting.


### PR DESCRIPTION
This branch proposes an example of the mpmc model with the **vSMTP process** communicating with the **delivery process**.
there isn't any implementation of the vMIME process because I want this example as small and easy to read as possible.

Here is the way it works.
1. the **vSMTP process** treats incoming SMTP transactions (parsing, rule engine etc ...):
   - once the email is complete, the **vSMTP process** writes the email as JSON using the MailContext structure on disk (delivery queue)
   - the **vSMTP process** sends the **message id** of the email to the **delivery process**
4. when the **delivery process** receive the message id:
    - it reads the email from the queue
    - tries to send the email
    - remove the email from the queue

Please check the code and ask any changes in the way it works.
the vMIME process will be added after this PR has been merged.