### PR TITLE
Parser integration

### DIFF
--- a/benches/receiver.rs
+++ b/benches/receiver.rs
@@ -4,8 +4,12 @@ use criterion::{
     criterion_group, criterion_main, measurement::WallTime, Bencher, BenchmarkId, Criterion,
 };
 use vsmtp::{
-    config::server_config::ServerConfig, model::mail::MailContext, resolver::DataEndResolver,
-    rules::address::Address, smtp::code::SMTPReplyCode, test_helpers::test_receiver,
+    config::server_config::ServerConfig,
+    model::mail::{Body, MailContext},
+    resolver::DataEndResolver,
+    rules::address::Address,
+    smtp::code::SMTPReplyCode,
+    test_helpers::test_receiver,
 };
 
 struct DefaultResolverTest;
@@ -56,7 +60,10 @@ fn criterion_benchmark(c: &mut Criterion) {
                     ctx.envelop.rcpt,
                     HashSet::from([Address::new("aa@bb").unwrap()])
                 );
-                assert_eq!(ctx.body, "");
+                assert!(match &ctx.body {
+                    Body::Raw(body) => body.is_empty(),
+                    _ => false,
+                });
 
                 Ok(SMTPReplyCode::Code250)
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,7 @@
 use vsmtp::config::log_channel::DELIVER;
 use vsmtp::config::server_config::ServerConfig;
 use vsmtp::mime::parser::MailMimeParser;
+use vsmtp::model::mail::Body;
 use vsmtp::resolver::deliver_queue::{DeliverQueueResolver, Queue};
 use vsmtp::resolver::maildir_resolver::MailDirResolver;
 use vsmtp::resolver::DataEndResolver;
@@ -114,11 +115,14 @@ async fn v_mime(
         let mail: vsmtp::model::mail::MailContext =
             { serde_json::from_str(&std::fs::read_to_string(&file_to_process)?)? };
 
-        match MailMimeParser::default().parse(mail.body.as_bytes()) {
-            Ok(_mail_mime) => {
-                // TODO: postq rule engine
+        match mail.body {
+            Body::Parsed(_) => {
+                todo!("run postq rule engine")
             }
-            Err(e) => todo!("handle error, continue receive message {}", e),
+            Body::Raw(raw) => MailMimeParser::default()
+                .parse(raw.as_bytes())
+                .and_then(|_| todo!("run postq rule engine"))
+                .expect("handle errors when parsing email in vMIME"),
         }
 
         delivery_sender.send(message_id.to_string()).unwrap();

--- a/src/mime/error.rs
+++ b/src/mime/error.rs
@@ -1,5 +1,6 @@
 // NOTE: should be improved
 
+#[derive(Debug)]
 pub enum ParserError {
     InvalidInput,
     InvalidMail(String),

--- a/src/mime/mail.rs
+++ b/src/mime/mail.rs
@@ -3,7 +3,7 @@ use super::mime_type::Mime;
 /// we use Vec instead of a HashMap because header ordering is important.
 pub type MailHeaders = Vec<(String, String)>;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 /// see rfc5322 (section 2.1 and 2.3)
 pub enum BodyType {
     Regular(Vec<String>),
@@ -11,7 +11,7 @@ pub enum BodyType {
     Undefined,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct Mail {
     pub headers: MailHeaders,
     pub body: BodyType,

--- a/src/mime/mime_type.rs
+++ b/src/mime/mime_type.rs
@@ -3,7 +3,7 @@ use super::{
     mail::Mail,
 };
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct MimeHeader {
     pub name: String,
     pub value: String,
@@ -11,14 +11,14 @@ pub struct MimeHeader {
     pub args: std::collections::HashMap<String, String>,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub enum MimeBodyType {
     Regular(Vec<String>),
     Multipart(MimeMultipart),
     Embedded(Mail),
 }
 
-#[derive(Debug, Default, PartialEq)]
+#[derive(Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct MimeMultipart {
     pub preamble: String,
     pub parts: Vec<Mime>,
@@ -61,7 +61,7 @@ impl MimeHeader {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct Mime {
     pub headers: Vec<MimeHeader>,
     pub content: MimeBodyType,

--- a/src/mime/mod.rs
+++ b/src/mime/mod.rs
@@ -1,5 +1,5 @@
 mod error;
-mod mail;
+pub mod mail;
 mod mime_type;
 pub mod parser;
 pub mod tests;

--- a/src/model/mail.rs
+++ b/src/model/mail.rs
@@ -39,8 +39,14 @@ impl Default for MessageMetadata {
 }
 
 #[derive(serde::Deserialize, serde::Serialize)]
+pub enum Body {
+    Raw(String),
+    Parsed(Box<crate::mime::mail::Mail>),
+}
+
+#[derive(serde::Deserialize, serde::Serialize)]
 pub struct MailContext {
     pub envelop: super::envelop::Envelop,
-    pub body: String,
+    pub body: Body,
     pub metadata: Option<MessageMetadata>,
 }

--- a/src/resolver/maildir_resolver.rs
+++ b/src/resolver/maildir_resolver.rs
@@ -16,7 +16,7 @@
 **/
 use crate::{
     config::{log_channel::RESOLVER, server_config::ServerConfig},
-    model::mail::{MailContext, MessageMetadata},
+    model::mail::{Body, MailContext, MessageMetadata},
     rules::address::Address,
     smtp::code::SMTPReplyCode,
 };
@@ -171,16 +171,21 @@ impl DataEndResolver for MailDirResolver {
             if crate::rules::rule_engine::user_exists(rcpt.local_part()) {
                 log::debug!(target: RESOLVER, "writing email to {}'s inbox.", rcpt);
 
-                if let Err(error) =
-                    Self::write_to_maildir(rcpt, mail.metadata.as_ref().unwrap(), &mail.body)
-                {
-                    log::error!(
-                        target: RESOLVER,
-                        "Couldn't write email to inbox: {:?}",
-                        error
-                    );
+                match &mail.body {
+                    Body::Raw(content) => {
+                        if let Err(error) =
+                            Self::write_to_maildir(rcpt, mail.metadata.as_ref().unwrap(), content)
+                        {
+                            log::error!(
+                                target: RESOLVER,
+                                "Couldn't write email to inbox: {:?}",
+                                error
+                            );
 
-                    return Err(error);
+                            return Err(error);
+                        }
+                    }
+                    _ => todo!(),
                 }
             } else {
                 log::trace!(

--- a/src/rules/actions.rs
+++ b/src/rules/actions.rs
@@ -34,7 +34,9 @@ pub(super) mod vsl {
     use std::collections::HashSet;
 
     use crate::{
-        config::log_channel::RULES, model::mail::MessageMetadata, rules::address::Address,
+        config::log_channel::RULES,
+        model::mail::{Body, MessageMetadata},
+        rules::address::Address,
     };
 
     /// enqueue a block operation on the queue.
@@ -196,7 +198,7 @@ pub(super) mod vsl {
                 mail_from: mail,
                 rcpt,
             },
-            body: data.into(),
+            body: Body::Raw(data.into()),
             metadata,
         };
 

--- a/tests/integration/protocol/clair.rs
+++ b/tests/integration/protocol/clair.rs
@@ -4,7 +4,7 @@ mod tests {
     use crate::integration::protocol::get_test_config;
     use vsmtp::{
         config::server_config::{InnerSMTPConfig, InnerTlsConfig, ServerConfig, TlsSecurityLevel},
-        model::mail::MailContext,
+        model::mail::{Body, MailContext},
         resolver::DataEndResolver,
         rules::address::Address,
         smtp::code::SMTPReplyCode,
@@ -30,7 +30,10 @@ mod tests {
                     ctx.envelop.rcpt,
                     std::collections::HashSet::from([Address::new("aa@bb").unwrap()])
                 );
-                assert_eq!(ctx.body, "");
+                assert!(match &ctx.body {
+                    Body::Raw(body) => body.is_empty(),
+                    _ => false,
+                });
                 assert!(ctx.metadata.is_some());
 
                 Ok(SMTPReplyCode::Code250)
@@ -407,7 +410,10 @@ mod tests {
                             ctx.envelop.rcpt,
                             std::collections::HashSet::from([Address::new("aa@bb").unwrap()])
                         );
-                        assert_eq!(ctx.body, "mail one\n");
+                        assert!(match &ctx.body {
+                            Body::Raw(body) => body == "mail one\n",
+                            _ => false,
+                        });
                         assert!(ctx.metadata.is_some());
                     }
                     1 => {
@@ -417,7 +423,10 @@ mod tests {
                             ctx.envelop.rcpt,
                             std::collections::HashSet::from([Address::new("aa2@bb").unwrap()])
                         );
-                        assert_eq!(ctx.body, "mail two\n");
+                        assert!(match &ctx.body {
+                            Body::Raw(body) => body == "mail two\n",
+                            _ => false,
+                        });
                     }
                     _ => panic!(),
                 }
@@ -488,7 +497,10 @@ mod tests {
                             ctx.envelop.rcpt,
                             std::collections::HashSet::from([Address::new("aa@bb").unwrap()])
                         );
-                        assert_eq!(ctx.body, "mail one\n");
+                        assert!(match &ctx.body {
+                            Body::Raw(body) => body == "mail one\n",
+                            _ => false,
+                        });
                     }
                     1 => {
                         assert_eq!(ctx.envelop.helo, "foobar2");
@@ -497,7 +509,10 @@ mod tests {
                             ctx.envelop.rcpt,
                             std::collections::HashSet::from([Address::new("aa2@bb").unwrap()])
                         );
-                        assert_eq!(ctx.body, "mail two\n");
+                        assert!(match &ctx.body {
+                            Body::Raw(body) => body == "mail two\n",
+                            _ => false,
+                        });
                         assert!(ctx.metadata.is_some());
                     }
                     _ => panic!(),

--- a/tests/integration/protocol/rset.rs
+++ b/tests/integration/protocol/rset.rs
@@ -5,7 +5,7 @@ mod tests {
 
     use vsmtp::{
         config::server_config::ServerConfig,
-        model::mail::MailContext,
+        model::mail::{Body, MailContext},
         resolver::DataEndResolver,
         rules::address::Address,
         smtp::code::SMTPReplyCode,
@@ -31,7 +31,10 @@ mod tests {
                     ctx.envelop.rcpt,
                     HashSet::from([Address::new("b@c").unwrap()])
                 );
-                assert_eq!(ctx.body, "mail content wow\n");
+                assert!(match &ctx.body {
+                    Body::Raw(body) => body == "mail content wow\n",
+                    _ => false,
+                });
 
                 Ok(SMTPReplyCode::Code250)
             }
@@ -140,7 +143,10 @@ mod tests {
                     ctx.envelop.rcpt,
                     HashSet::from([Address::new("b@c").unwrap()])
                 );
-                assert_eq!(ctx.body, "mail content wow");
+                assert!(match &ctx.body {
+                    Body::Raw(body) => body == "mail content wow",
+                    _ => false,
+                });
 
                 Ok(SMTPReplyCode::Code250)
             }
@@ -192,7 +198,10 @@ mod tests {
                     ctx.envelop.rcpt,
                     HashSet::from([Address::new("toto@bar").unwrap()])
                 );
-                assert_eq!(ctx.body, "");
+                assert!(match &ctx.body {
+                    Body::Raw(body) => body.is_empty(),
+                    _ => false,
+                });
 
                 Ok(SMTPReplyCode::Code250)
             }
@@ -245,7 +254,10 @@ mod tests {
                         Address::new("toto3@bar").unwrap()
                     ])
                 );
-                assert_eq!(ctx.body, "");
+                assert!(match &ctx.body {
+                    Body::Raw(body) => body.is_empty(),
+                    _ => false,
+                });
 
                 Ok(SMTPReplyCode::Code250)
             }

--- a/tests/integration/protocol/utf8.rs
+++ b/tests/integration/protocol/utf8.rs
@@ -3,8 +3,8 @@ mod tests {
     use crate::integration::protocol::get_test_config;
     use vsmtp::test_helpers::test_receiver;
     use vsmtp::{
-        config::server_config::ServerConfig, model::mail::MailContext, resolver::DataEndResolver,
-        rules::address::Address, smtp::code::SMTPReplyCode,
+        config::server_config::ServerConfig, model::mail::Body, model::mail::MailContext,
+        resolver::DataEndResolver, rules::address::Address, smtp::code::SMTPReplyCode,
     };
 
     macro_rules! test_lang {
@@ -24,7 +24,11 @@ mod tests {
                         ctx.envelop.rcpt,
                         std::collections::HashSet::from([Address::new("aa@bb").unwrap()])
                     );
-                    assert_eq!(ctx.body, include_str!($lang_code));
+                    assert!(match &ctx.body {
+                        Body::Raw(body) => body == include_str!($lang_code),
+                        _ => false,
+                    });
+
                     Ok(SMTPReplyCode::Code250)
                 }
             }


### PR DESCRIPTION
The goal of this PR is to convert the base email body from a raw string to a parsed email that will be created when receiving the ``DataEnd`` command. Please check out #75 to see what it will be used for.

For now, a ``Body`` enum has been created to store eather a raw or parsed email content. This is used to fetch the email raw strings from the client during the``Data`` state, and parse the email on the ``DataEnd`` command.

```rust
pub enum Body {
    Raw(String),
    Parsed(Box<crate::mime::mail::Mail>),
}
```

this is a transitory PR while I work on a "deparser" of the structure.

Please ask for any change and give your opinion on the matter.