### PR TITLE
refact: cleanup how timeout are parsed (config.toml is not changed)

### DIFF
--- a/config/vsmtp.dev-local.toml
+++ b/config/vsmtp.dev-local.toml
@@ -37,8 +37,6 @@ spool_dir = "./tmp/var/spool/vsmtp"
 rcpt_count_max = 25
 disable_ehlo = false
 
-[smtp.timeout_client]
-
 [smtp.error]
 soft_count = 5
 hard_count = 10

--- a/src/config/server_config.rs
+++ b/src/config/server_config.rs
@@ -161,16 +161,22 @@ pub struct InnerSMTPErrorConfig {
     pub delay: std::time::Duration,
 }
 
+#[derive(Debug, Clone, serde::Deserialize)]
+#[serde(transparent)]
+pub struct DurationAlias {
+    #[serde(with = "humantime_serde")]
+    pub alias: std::time::Duration,
+}
+
 #[serde_as]
 #[derive(Debug, Clone, serde::Deserialize)]
 pub struct InnerSMTPConfig {
     pub spool_dir: String,
     pub disable_ehlo: bool,
-    #[serde_as(as = "std::collections::HashMap<DisplayFromStr, _>")]
-    // #[serde(with = "humantime_serde")]
-    pub timeout_client: std::collections::HashMap<StateSMTP, String>,
+    #[serde(default)]
+    #[serde_as(as = "Option<std::collections::HashMap<DisplayFromStr, _>>")]
+    pub timeout_client: Option<std::collections::HashMap<StateSMTP, DurationAlias>>,
     pub error: InnerSMTPErrorConfig,
-    // TODO: ? use serde_as ?
     pub code: Option<SMTPCode>,
     pub rcpt_count_max: Option<usize>,
 }


### PR DESCRIPTION
* Parsing of duration for timeout occure in the deserialization and not in the transaction
* perf should be improved
* field [smtp.timeout_client] is optional (but not overwrite but default if missing (todo))