### PR TITLE
CONTAINS_RCPT action

### DIFF
--- a/src/rules/actions.rs
+++ b/src/rules/actions.rs
@@ -346,6 +346,15 @@ pub(super) mod vsl {
         }
     }
 
+    /// check if the given object matches one of the incoming recipients.
+    pub fn __contains_rcpt(rcpts: &mut HashSet<Address>, object: &str) -> bool {
+        match acquire_engine().objects.read().unwrap().get(object) {
+            Some(object) => rcpts.iter().any(|rcpt| internal_is_rcpt(rcpt, object)),
+            // TODO: allow for user / domain search with a string.
+            _ => rcpts.iter().any(|rcpt| rcpt.full() == object),
+        }
+    }
+
     /// checks if the given user exists on the system.
     pub fn __user_exists(object: &str) -> bool {
         match acquire_engine().objects.read().unwrap().get(object) {

--- a/src/rules/currying.rhai
+++ b/src/rules/currying.rhai
@@ -36,6 +36,9 @@ let vsl = #{
     // given by the current RCPT TO command.
     IS_RCPT: |object| __is_rcpt(rcpt, object),
 
+    // checks if the object matches one of the recipients.
+    CONTAINS_RCPT: |object| __contains_rcpt(rcpts, object),
+
     // checks whether the specified user exists on the system.
     USER_EXISTS: |object| __user_exists(object),
 

--- a/src/rules/tests/rules/rcpt/contains_rcpt.vsl
+++ b/src/rules/tests/rules/rcpt/contains_rcpt.vsl
@@ -1,0 +1,35 @@
+obj val "john" "johndoe";
+obj fqdn "viridit" "viridit.com";
+obj addr "customer" "customer@company.com";
+obj addr "satan" "dangerous@satan.com";
+obj addr "green" "green@foo.com";
+
+rule preq "test_rcpt_user" #{
+  condition: || vsl.CONTAINS_RCPT("john"),
+  on_success: vsl.CONTINUE,
+  on_failure: vsl.DENY,
+};
+
+rule preq "test_rcpt_fqdn" #{
+  condition: || vsl.CONTAINS_RCPT("viridit"),
+  on_success: vsl.CONTINUE,
+  on_failure: vsl.DENY,
+};
+
+rule preq "test_rcpt_email" #{
+  condition: || vsl.CONTAINS_RCPT("customer"),
+  on_success: vsl.CONTINUE,
+  on_failure: vsl.DENY,
+};
+
+rule preq "test_not_in_rcpts_1" #{
+  condition: || !vsl.CONTAINS_RCPT("satan"),
+  on_success: vsl.CONTINUE,
+  on_failure: vsl.DENY,
+};
+
+rule preq "test_not_in_rcpts_2" #{
+  condition: || !vsl.CONTAINS_RCPT("green"),
+  on_success: vsl.ACCEPT,
+  on_failure: vsl.DENY,
+};

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -221,10 +221,7 @@ impl Transaction<'_> {
 
                 self.rule_engine.add_data("data", parsed);
 
-                let status = self.rule_engine.run_when("preq");
-
-                // TODO: block & deny should quarantine the email.
-                if let Status::Block | Status::Deny = status {
+                if let Status::Block | Status::Deny = self.rule_engine.run_when("preq") {
                     return ProcessedEvent::ReplyChangeState(
                         StateSMTP::Stop,
                         SMTPReplyCode::Code554,
@@ -240,7 +237,7 @@ impl Transaction<'_> {
                     );
                 }
 
-                // getting the server's envelop, that could have mutated in the
+                // getting the server's envelop that could have mutated in the
                 // rule engine.
                 match self.rule_engine.get_scoped_envelop() {
                     Some((envelop, mail)) => {


### PR DESCRIPTION
Added the `CONTAINS_RCPT` action.
It enables the user to check for a specific recipient in the `preq` stage.

```rust
rule preq "deny_green_recipient" #{
  condition: || !vsl.CONTAINS_RCPT("green"),
  on_success: vsl.ACCEPT,
  on_failure: vsl.DENY,
};
```

closes #92
closes #84 