### PR TITLE
MBox Resolver

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 edition = "2021"
 
 name = "vsmtp"
-version = "0.7.3"
+version = "0.8.2"
 license = "GPLv3"
 
 authors = ["Team viridIT <https://viridit.com/>"]

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,7 @@
 use vsmtp::config::get_logger_config;
 use vsmtp::config::server_config::ServerConfig;
 use vsmtp::resolver::maildir_resolver::MailDirResolver;
+use vsmtp::resolver::mbox_resolver::MBoxResolver;
 use vsmtp::resolver::smtp_resolver::SMTPResolver;
 use vsmtp::rules::rule_engine;
 use vsmtp::server::ServerVSMTP;
@@ -54,6 +55,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     server
         .with_resolver("maildir", MailDirResolver::default())
         .with_resolver("smtp", SMTPResolver::default())
+        .with_resolver("mbox", MBoxResolver::default())
         .listen_and_serve()
         .await
 }

--- a/src/resolver/maildir_resolver.rs
+++ b/src/resolver/maildir_resolver.rs
@@ -22,25 +22,6 @@ use crate::{
 
 use super::Resolver;
 
-/// sets user & group rights to the given file / folder.
-fn chown_file(path: &std::path::Path, user: &users::User) -> std::io::Result<()> {
-    if unsafe {
-        libc::chown(
-            // NOTE: to_string_lossy().as_bytes() isn't the right way of converting a PathBuf
-            //       to a CString because it is platform independent.
-            std::ffi::CString::new(path.to_string_lossy().as_bytes())?.as_ptr(),
-            user.uid(),
-            user.uid(),
-        )
-    } != 0
-    {
-        log::error!("unable to setuid of user {:?}", user.name());
-        return Err(std::io::Error::last_os_error());
-    }
-
-    Ok(())
-}
-
 #[derive(Default)]
 pub struct MailDirResolver;
 
@@ -78,8 +59,8 @@ impl MailDirResolver {
                 // create and set rights for the MailDir folder if it doesn't exists.
                 if !maildir.exists() {
                     std::fs::create_dir_all(&maildir)?;
-                    chown_file(&maildir, &user)?;
-                    chown_file(
+                    super::chown_file(&maildir, &user)?;
+                    super::chown_file(
                         maildir.parent().ok_or_else(|| {
                             std::io::Error::new(
                                 std::io::ErrorKind::Other,
@@ -101,7 +82,7 @@ impl MailDirResolver {
 
                 std::io::Write::write_all(&mut email, content.as_bytes())?;
 
-                chown_file(&maildir, &user)?;
+                super::chown_file(&maildir, &user)?;
             }
             None => {
                 log::error!("unable to get user '{}' by name", rcpt.local_part());

--- a/src/resolver/mbox_resolver.rs
+++ b/src/resolver/mbox_resolver.rs
@@ -45,11 +45,11 @@ impl Resolver for MBoxResolver {
                 .map(|metadata| metadata.timestamp)
                 .unwrap_or_else(std::time::SystemTime::now)
                 .into();
-            let timestamp = timestamp.to_rfc2822();
+            let timestamp = timestamp.format("%c");
 
             let content = match &ctx.body {
                 crate::model::mail::Body::Raw(raw) => {
-                    format!("From {} {timestamp}\n\n{raw}\n", ctx.envelop.mail_from)
+                    format!("From {} {timestamp}\n{raw}\n", ctx.envelop.mail_from)
                 }
                 crate::model::mail::Body::Parsed(parsed) => {
                     let (headers, body) = parsed.to_raw();

--- a/src/resolver/mbox_resolver.rs
+++ b/src/resolver/mbox_resolver.rs
@@ -46,7 +46,18 @@ impl Resolver for MBoxResolver {
                 .unwrap_or_else(std::time::SystemTime::now)
                 .into();
 
-            let content = format!("From {} {}", ctx.envelop.mail_from, timestamp);
+            let content = match &ctx.body {
+                crate::model::mail::Body::Raw(raw) => {
+                    format!("From {} {timestamp}\n{raw}\n", ctx.envelop.mail_from)
+                }
+                crate::model::mail::Body::Parsed(parsed) => {
+                    let (headers, body) = parsed.to_raw();
+                    format!(
+                        "From {} {timestamp}\n{headers}\n{body}\n",
+                        ctx.envelop.mail_from
+                    )
+                }
+            };
 
             std::io::Write::write_all(&mut file, content.as_bytes())?;
 

--- a/src/resolver/mbox_resolver.rs
+++ b/src/resolver/mbox_resolver.rs
@@ -45,15 +45,16 @@ impl Resolver for MBoxResolver {
                 .map(|metadata| metadata.timestamp)
                 .unwrap_or_else(std::time::SystemTime::now)
                 .into();
+            let timestamp = timestamp.to_rfc2822();
 
             let content = match &ctx.body {
                 crate::model::mail::Body::Raw(raw) => {
-                    format!("From {} {timestamp}\n{raw}\n", ctx.envelop.mail_from)
+                    format!("From {} {timestamp}\n\n{raw}\n", ctx.envelop.mail_from)
                 }
                 crate::model::mail::Body::Parsed(parsed) => {
                     let (headers, body) = parsed.to_raw();
                     format!(
-                        "From {} {timestamp}\n{headers}\n{body}\n",
+                        "From {} {timestamp}\n{headers}\n\n{body}\n",
                         ctx.envelop.mail_from
                     )
                 }

--- a/src/resolver/mbox_resolver.rs
+++ b/src/resolver/mbox_resolver.rs
@@ -1,0 +1,62 @@
+/**
+ * vSMTP mail transfer agent
+ * Copyright (C) 2021 viridIT SAS
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or any later version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see https://www.gnu.org/licenses/.
+ *
+**/
+use crate::{
+    config::{log_channel::RESOLVER, server_config::ServerConfig},
+    model::mail::MailContext,
+};
+
+use super::Resolver;
+
+#[derive(Default)]
+/// resolver use to write emails on the system following the
+/// application/mbox Media Type.
+/// (see [rfc4155](https://datatracker.ietf.org/doc/html/rfc4155#appendix-A))
+pub struct MBoxResolver;
+
+#[async_trait::async_trait]
+impl Resolver for MBoxResolver {
+    async fn deliver(&self, _: &ServerConfig, ctx: &MailContext) -> std::io::Result<()> {
+        for rcpt in ctx.envelop.rcpt.iter() {
+            // NOTE: only linux system is supported here, is the
+            //       path to all mboxes always /var/mail ?
+            let mbox = std::path::PathBuf::from_iter(["/var/mail/", rcpt.local_part()]);
+            let mut file = std::fs::OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(&mbox)?;
+
+            let timestamp: chrono::DateTime<chrono::offset::Utc> = ctx
+                .metadata
+                .as_ref()
+                .map(|metadata| metadata.timestamp)
+                .unwrap_or_else(std::time::SystemTime::now)
+                .into();
+
+            let content = format!("From {} {}", ctx.envelop.mail_from, timestamp);
+
+            std::io::Write::write_all(&mut file, content.as_bytes())?;
+
+            log::debug!(
+                target: RESOLVER,
+                "{} bytes written to {}'s mbox",
+                content.len(),
+                rcpt
+            );
+        }
+        Ok(())
+    }
+}

--- a/src/resolver/mod.rs
+++ b/src/resolver/mod.rs
@@ -19,6 +19,7 @@ use crate::{
 };
 
 pub mod maildir_resolver;
+pub mod mbox_resolver;
 pub mod smtp_resolver;
 
 #[async_trait::async_trait]

--- a/src/rules/currying.rhai
+++ b/src/rules/currying.rhai
@@ -136,8 +136,13 @@ let vsl = #{
         metadata.resolver = "maildir";
     },
 
-    // set resolver to smtp.
+    // set resolver to smtp (lettre).
     USE_SMTP: || {
         metadata.resolver = "smtp";
+    },
+
+    // set resolver to mbox (default mbox database format).
+    USE_MBOX: || {
+        metadata.resolver = "mbox";
     },
 };


### PR DESCRIPTION
- the `vsl.USE_MBOX` action is now available
- the mbox delivery system is implemented

the mbox file format is used to store emails on disk. It is a little bit different that Maildir, as all emails are stored inside one file.
checkout out the [rfc](https://datatracker.ietf.org/doc/html/rfc4155) for more information.