### PR TITLE
Anyhow

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,16 +20,16 @@ clap = { version = "3.0.4", features = ["derive"] }
 
 libc = "0.2.112"
 socket2 = "0.4.2"
-trust-dns-resolver = "0.20.3"
+anyhow = "1.0"
 
 serde = { version = "1.0.133", features = ["derive"] }
 serde_derive = "1.0.133"
 serde_with = { version = "1.11.0", features = ["macros"] }
 serde_json = "1.0.74"
-
 toml = "0.5.8"
 humantime = "2.1.0"
 humantime-serde = "1.0.1"
+
 addr = { version = "0.15.2" } # features = ["net"] } # create some issue..
 regex = "1.5.4"
 iprange = "0.6.6"
@@ -40,6 +40,7 @@ rhai = { version = "1.4.0", features = ["unchecked", "sync"] }
 
 # the 0.10 release is more stable than the 0.9 and enable async support.
 lettre = "0.10.0-rc.4"
+trust-dns-resolver = "0.20.3"
 
 async-trait = "0.1.52"
 lazy_static = "1.4"

--- a/benches/receiver.rs
+++ b/benches/receiver.rs
@@ -21,7 +21,7 @@ impl DataEndResolver for DefaultResolverTest {
         &mut self,
         _: &ServerConfig,
         _: &MailContext,
-    ) -> Result<SMTPReplyCode, std::io::Error> {
+    ) -> anyhow::Result<SMTPReplyCode> {
         Ok(SMTPReplyCode::Code250)
     }
 }
@@ -61,7 +61,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                 &mut self,
                 _: &ServerConfig,
                 ctx: &MailContext,
-            ) -> Result<SMTPReplyCode, std::io::Error> {
+            ) -> anyhow::Result<SMTPReplyCode> {
                 assert_eq!(ctx.envelop.helo, "foobar");
                 assert_eq!(ctx.envelop.mail_from.full(), "john@doe");
                 assert_eq!(

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -10,9 +10,7 @@ pub mod log_channel {
     pub const DELIVER: &str = "deliver";
 }
 
-pub fn get_logger_config(
-    config: &server_config::ServerConfig,
-) -> Result<log4rs::Config, std::io::Error> {
+pub fn get_logger_config(config: &server_config::ServerConfig) -> anyhow::Result<log4rs::Config> {
     use log4rs::*;
 
     let console = append::console::ConsoleAppender::builder()
@@ -51,6 +49,6 @@ pub fn get_logger_config(
         )
         .map_err(|e| {
             e.errors().iter().for_each(|e| log::error!("{}", e));
-            std::io::Error::new(std::io::ErrorKind::Other, e)
+            anyhow::anyhow!(e)
         })
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,7 +30,7 @@ struct Args {
 }
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
+async fn main() -> anyhow::Result<()> {
     let args = <Args as clap::StructOpt>::parse();
     println!("Loading with configuration: '{}'", args.config);
 

--- a/src/mime/error.rs
+++ b/src/mime/error.rs
@@ -9,6 +9,8 @@ pub enum ParserError {
     MisplacedBoundary(String),
 }
 
+impl std::error::Error for ParserError {}
+
 pub type ParserResult<T> = Result<T, ParserError>;
 
 impl std::fmt::Display for ParserError {

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -53,15 +53,10 @@ impl Queue {
         &self,
         config: &ServerConfig,
         ctx: &crate::model::mail::MailContext,
-    ) -> std::io::Result<()> {
+    ) -> anyhow::Result<()> {
         let message_id = match ctx.metadata.as_ref() {
             Some(metadata) => &metadata.message_id,
-            None => {
-                return Err(std::io::Error::new(
-                    std::io::ErrorKind::NotFound,
-                    "metadata not found",
-                ))
-            }
+            None => anyhow::bail!("mail metadata not found"),
         };
 
         let to_deliver = self.to_path(&config.smtp.spool_dir)?.join(message_id);

--- a/src/resolver/mbox_resolver.rs
+++ b/src/resolver/mbox_resolver.rs
@@ -29,7 +29,7 @@ pub struct MBoxResolver;
 
 #[async_trait::async_trait]
 impl Resolver for MBoxResolver {
-    async fn deliver(&self, _: &ServerConfig, ctx: &MailContext) -> std::io::Result<()> {
+    async fn deliver(&self, _: &ServerConfig, ctx: &MailContext) -> anyhow::Result<()> {
         for rcpt in ctx.envelop.rcpt.iter() {
             match crate::rules::rule_engine::get_user_by_name(rcpt.local_part()) {
                 Some(user) => {
@@ -72,13 +72,7 @@ impl Resolver for MBoxResolver {
                         rcpt
                     );
                 }
-                _ => {
-                    log::error!("unable to get user '{}' by name", rcpt.local_part());
-                    return Err(std::io::Error::new(
-                        std::io::ErrorKind::Other,
-                        "unable to get user",
-                    ));
-                }
+                _ => anyhow::bail!("unable to get user '{}' by name", rcpt.local_part()),
             }
         }
         Ok(())

--- a/src/resolver/mod.rs
+++ b/src/resolver/mod.rs
@@ -33,7 +33,7 @@ pub trait DataEndResolver {
 
 #[async_trait::async_trait]
 pub trait Resolver {
-    async fn deliver(&self, config: &ServerConfig, mail: &MailContext) -> std::io::Result<()>;
+    async fn deliver(&self, config: &ServerConfig, mail: &MailContext) -> anyhow::Result<()>;
 }
 
 /// sets user & group rights to the given file / folder.

--- a/src/resolver/mod.rs
+++ b/src/resolver/mod.rs
@@ -28,7 +28,7 @@ pub trait DataEndResolver {
         &mut self,
         config: &ServerConfig,
         mail: &MailContext,
-    ) -> std::io::Result<SMTPReplyCode>;
+    ) -> anyhow::Result<SMTPReplyCode>;
 }
 
 #[async_trait::async_trait]

--- a/src/rules/rule_engine.rs
+++ b/src/rules/rule_engine.rs
@@ -30,8 +30,6 @@ use std::net::IpAddr;
 use std::sync::Mutex;
 use std::{
     collections::{BTreeMap, HashSet},
-    error::Error,
-    fs,
     net::Ipv4Addr,
     path::Path,
     str::FromStr,
@@ -171,10 +169,7 @@ impl<'a> RuleEngine<'a> {
     }
 
     /// empty the operation queue and executing all operations stored.
-    pub(crate) fn execute_operation_queue(
-        &mut self,
-        ctx: &MailContext,
-    ) -> Result<(), Box<dyn Error>> {
+    pub(crate) fn execute_operation_queue(&mut self, ctx: &MailContext) -> anyhow::Result<()> {
         for op in self
             .scope
             .get_value::<OperationQueue>("__OPERATION_QUEUE")
@@ -257,7 +252,7 @@ pub struct RhaiEngine<U: Users> {
 
 impl<U: Users> RhaiEngine<U> {
     /// create an engine from a script encoded in raw bytes.
-    pub fn from_bytes(src: &[u8], users: U) -> Result<Self, Box<dyn Error>> {
+    pub fn from_bytes(src: &[u8], users: U) -> anyhow::Result<Self> {
         let mut engine = Engine::new();
         let objects = Arc::new(RwLock::new(BTreeMap::new()));
         let shared_obj = objects.clone();
@@ -657,21 +652,21 @@ impl<U: Users> RhaiEngine<U> {
 impl RhaiEngine<users::UsersCache> {
     /// creates a new instance of the rule engine, reading all files in
     /// src_path parameter.
-    fn new(src_path: &str) -> Result<Self, Box<dyn Error>> {
+    fn new(src_path: &str) -> anyhow::Result<Self> {
         // load all sources from file.
         // this function is declared here since it isn't needed anywhere else.
-        fn load_sources(path: &Path) -> Result<Vec<String>, Box<dyn Error>> {
+        fn load_sources(path: &Path) -> anyhow::Result<Vec<String>> {
             let mut buffer = vec![];
 
             if path.is_file() {
                 match path.extension() {
                     Some(extension) if extension == "vsl" => {
-                        buffer.push(format!("{}\n", fs::read_to_string(path)?))
+                        buffer.push(format!("{}\n", std::fs::read_to_string(path)?))
                     }
                     _ => {}
                 };
             } else if path.is_dir() {
-                for entry in fs::read_dir(path)? {
+                for entry in std::fs::read_dir(path)? {
                     let dir = entry?;
                     buffer.extend(load_sources(&dir.path())?);
                 }
@@ -694,24 +689,21 @@ impl RhaiEngine<users::mock::MockUsers> {
     /// creates a new instance of the rule engine, used for tests.
     /// allow unused is () because this new static method is
     /// for tests only.
-    pub(super) fn new(
-        src_path: &str,
-        users: users::mock::MockUsers,
-    ) -> Result<Self, Box<dyn Error>> {
+    pub(super) fn new(src_path: &str, users: users::mock::MockUsers) -> anyhow::Result<Self> {
         // load all sources from file.
         // this function is declared here since it isn't needed anywhere else.
-        fn load_sources(path: &Path) -> Result<Vec<String>, Box<dyn Error>> {
+        fn load_sources(path: &Path) -> anyhow::Result<Vec<String>> {
             let mut buffer = vec![];
 
             if path.is_file() {
                 match path.extension() {
                     Some(extension) if extension == "vsl" => {
-                        buffer.push(format!("{}\n", fs::read_to_string(path)?))
+                        buffer.push(format!("{}\n", std::fs::read_to_string(path)?))
                     }
                     _ => {}
                 };
             } else if path.is_dir() {
-                for entry in fs::read_dir(path)? {
+                for entry in std::fs::read_dir(path)? {
                     let dir = entry?;
                     buffer.extend(load_sources(&dir.path())?);
                 }
@@ -814,7 +806,7 @@ pub fn set_rules_path(src: &'static str) {
 /// not calling this method when initializing your server could lead to
 /// undetected configuration errors and a slow process for the first connection.
 #[cfg(not(test))]
-pub fn init(src: &'static str) -> Result<(), Box<dyn Error>> {
+pub fn init(src: &'static str) -> anyhow::Result<()> {
     set_rules_path(src);
 
     // creating a temporary engine to try construction.

--- a/src/rules/tests/mail.rs
+++ b/src/rules/tests/mail.rs
@@ -149,7 +149,7 @@ pub mod test {
             &mut self,
             _: &ServerConfig,
             ctx: &MailContext,
-        ) -> Result<SMTPReplyCode, std::io::Error> {
+        ) -> anyhow::Result<SMTPReplyCode> {
             println!("{:?}", ctx.envelop.rcpt);
             println!("{:?}", ctx.envelop.mail_from);
 

--- a/src/rules/tests/mod.rs
+++ b/src/rules/tests/mod.rs
@@ -67,7 +67,7 @@ pub mod helpers {
         users: users::mock::MockUsers,
         smtp_input: &[u8],
         expected_output: &[u8],
-    ) -> Result<(), std::io::Error> {
+    ) -> anyhow::Result<()> {
         let mut config: ServerConfig = toml::from_str(
             &std::fs::read_to_string(config_path).expect("failed to read config from file"),
         )

--- a/src/rules/tests/rcpt.rs
+++ b/src/rules/tests/rcpt.rs
@@ -229,7 +229,7 @@ pub mod test {
             &mut self,
             _: &ServerConfig,
             ctx: &MailContext,
-        ) -> Result<SMTPReplyCode, std::io::Error> {
+        ) -> anyhow::Result<SMTPReplyCode> {
             assert!(ctx
                 .envelop
                 .rcpt
@@ -313,7 +313,7 @@ pub mod test {
             &mut self,
             _: &ServerConfig,
             ctx: &MailContext,
-        ) -> Result<SMTPReplyCode, std::io::Error> {
+        ) -> anyhow::Result<SMTPReplyCode> {
             println!("{:?}", ctx.envelop.rcpt);
 
             assert!(ctx
@@ -401,7 +401,7 @@ pub mod test {
             &mut self,
             _: &ServerConfig,
             ctx: &MailContext,
-        ) -> Result<SMTPReplyCode, std::io::Error> {
+        ) -> anyhow::Result<SMTPReplyCode> {
             println!("{:?}", ctx.envelop.rcpt);
 
             assert!(ctx

--- a/src/server.rs
+++ b/src/server.rs
@@ -36,9 +36,7 @@ pub struct ServerVSMTP {
 }
 
 impl ServerVSMTP {
-    pub async fn new(
-        config: std::sync::Arc<ServerConfig>,
-    ) -> Result<Self, Box<dyn std::error::Error>> {
+    pub async fn new(config: std::sync::Arc<ServerConfig>) -> anyhow::Result<Self> {
         // NOTE: Err type is core::convert::Infallible, it's safe to unwrap.
         let spool_dir =
             <std::path::PathBuf as std::str::FromStr>::from_str(&config.smtp.spool_dir).unwrap();
@@ -75,7 +73,7 @@ impl ServerVSMTP {
         self
     }
 
-    pub async fn listen_and_serve(&mut self) -> Result<(), Box<dyn std::error::Error>> {
+    pub async fn listen_and_serve(&mut self) -> anyhow::Result<()> {
         let delivery_buffer_size = self
             .config
             .delivery
@@ -208,7 +206,7 @@ impl ServerVSMTP {
         conn: &mut Connection<'_, S>,
         working_sender: std::sync::Arc<tokio::sync::mpsc::Sender<ProcessMessage>>,
         tls_config: Option<std::sync::Arc<rustls::ServerConfig>>,
-    ) -> Result<(), std::io::Error>
+    ) -> anyhow::Result<()>
     where
         S: std::io::Read + std::io::Write,
     {

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -58,7 +58,7 @@ impl DataEndResolver for DefaultResolverTest {
         &mut self,
         _: &ServerConfig,
         _: &MailContext,
-    ) -> Result<SMTPReplyCode, std::io::Error> {
+    ) -> anyhow::Result<SMTPReplyCode> {
         Ok(SMTPReplyCode::Code250)
     }
 }
@@ -70,7 +70,7 @@ pub async fn test_receiver<T: DataEndResolver>(
     smtp_input: &[u8],
     expected_output: &[u8],
     config: std::sync::Arc<ServerConfig>,
-) -> Result<(), std::io::Error> {
+) -> anyhow::Result<()> {
     let mut written_data = Vec::new();
     let mut mock = Mock::new(smtp_input.to_vec(), &mut written_data);
     let mut io = IoService::new(&mut mock);

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -2,7 +2,7 @@ use crate::config::{default::DEFAULT_CONFIG, server_config::ServerConfig};
 
 fn get_signing_key_from_file(
     rsa_path: &str,
-) -> Result<std::sync::Arc<dyn rustls::sign::SigningKey>, std::io::Error> {
+) -> anyhow::Result<std::sync::Arc<dyn rustls::sign::SigningKey>> {
     let rsa_file = std::fs::File::open(&rsa_path)?;
     let mut reader = std::io::BufReader::new(rsa_file);
 
@@ -17,16 +17,13 @@ fn get_signing_key_from_file(
 
     if let Some(key) = private_keys_rsa.first() {
         rustls::sign::any_supported_type(key)
-            .map_err(|_| std::io::Error::new(std::io::ErrorKind::Other, "cannot parse signing key"))
+            .map_err(|_| anyhow::anyhow!("cannot parse signing key"))
     } else {
-        Err(std::io::Error::new(
-            std::io::ErrorKind::NotFound,
-            "private key missing",
-        ))
+        anyhow::bail!("private key missing")
     }
 }
 
-fn get_cert_from_file(fullchain_path: &str) -> Result<Vec<rustls::Certificate>, std::io::Error> {
+fn get_cert_from_file(fullchain_path: &str) -> std::io::Result<Vec<rustls::Certificate>> {
     let fullchain_file = std::fs::File::open(&fullchain_path)?;
     let mut reader = std::io::BufReader::new(fullchain_file);
     rustls_pemfile::certs(&mut reader).map(|certs| {

--- a/tests/integration/protocol/clair.rs
+++ b/tests/integration/protocol/clair.rs
@@ -23,7 +23,7 @@ mod tests {
                 &mut self,
                 _: &ServerConfig,
                 ctx: &MailContext,
-            ) -> Result<SMTPReplyCode, std::io::Error> {
+            ) -> anyhow::Result<SMTPReplyCode> {
                 assert_eq!(ctx.envelop.helo, "foobar");
                 assert_eq!(ctx.envelop.mail_from.full(), "john@doe");
                 assert_eq!(
@@ -413,7 +413,7 @@ mod tests {
                 &mut self,
                 _: &ServerConfig,
                 ctx: &MailContext,
-            ) -> Result<SMTPReplyCode, std::io::Error> {
+            ) -> anyhow::Result<SMTPReplyCode> {
                 match self.count {
                     0 => {
                         assert_eq!(ctx.envelop.helo, "foobar");
@@ -501,7 +501,7 @@ mod tests {
                 &mut self,
                 _: &ServerConfig,
                 ctx: &MailContext,
-            ) -> Result<SMTPReplyCode, std::io::Error> {
+            ) -> anyhow::Result<SMTPReplyCode> {
                 match self.count {
                     0 => {
                         assert_eq!(ctx.envelop.helo, "foobar");

--- a/tests/integration/protocol/rset.rs
+++ b/tests/integration/protocol/rset.rs
@@ -24,7 +24,7 @@ mod tests {
                 &mut self,
                 _: &ServerConfig,
                 ctx: &MailContext,
-            ) -> Result<SMTPReplyCode, std::io::Error> {
+            ) -> anyhow::Result<SMTPReplyCode> {
                 assert_eq!(ctx.envelop.helo, "foo");
                 assert_eq!(ctx.envelop.mail_from.full(), "a@b");
                 assert_eq!(
@@ -139,7 +139,7 @@ mod tests {
                 &mut self,
                 _: &ServerConfig,
                 ctx: &MailContext,
-            ) -> Result<SMTPReplyCode, std::io::Error> {
+            ) -> anyhow::Result<SMTPReplyCode> {
                 assert_eq!(ctx.envelop.helo, "foo2");
                 assert_eq!(ctx.envelop.mail_from.full(), "d@e");
                 assert_eq!(
@@ -195,7 +195,7 @@ mod tests {
                 &mut self,
                 _: &ServerConfig,
                 ctx: &MailContext,
-            ) -> Result<SMTPReplyCode, std::io::Error> {
+            ) -> anyhow::Result<SMTPReplyCode> {
                 assert_eq!(ctx.envelop.helo, "foo");
                 assert_eq!(ctx.envelop.mail_from.full(), "foo@foo");
                 assert_eq!(
@@ -249,7 +249,7 @@ mod tests {
                 &mut self,
                 _: &ServerConfig,
                 ctx: &MailContext,
-            ) -> Result<SMTPReplyCode, std::io::Error> {
+            ) -> anyhow::Result<SMTPReplyCode> {
                 assert_eq!(ctx.envelop.helo, "foo");
                 assert_eq!(ctx.envelop.mail_from.full(), "foo2@foo");
                 assert_eq!(

--- a/tests/integration/protocol/utf8.rs
+++ b/tests/integration/protocol/utf8.rs
@@ -17,7 +17,7 @@ mod tests {
                     &mut self,
                     _: &ServerConfig,
                     ctx: &MailContext,
-                ) -> Result<SMTPReplyCode, std::io::Error> {
+                ) -> anyhow::Result<SMTPReplyCode> {
                     assert_eq!(ctx.envelop.helo, "foobar".to_string());
                     assert_eq!(ctx.envelop.mail_from.full(), "john@doe".to_string());
                     assert_eq!(


### PR DESCRIPTION
Added the [anyhow](https://github.com/dtolnay/anyhow) crate and replaced almost all failing function, only when necessary, meaning:

- replaced by anyhow when we were forced to cast an error to a specific one but didn't really care about the error type returned (application level).
- not replaced if the function could be transformed into a library and that the error returned needed to be specific.

This change result in smaller and better errors, and better error management.
I didn't update the version number since it's just a small internal change.