### PR TITLE
Quarantine

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 edition = "2021"
 
 name = "vsmtp"
-version = "0.8.3"
+version = "0.8.4"
 license = "GPLv3"
 
 authors = ["Team viridIT <https://viridit.com/>"]

--- a/src/processes/mime.rs
+++ b/src/processes/mime.rs
@@ -84,6 +84,19 @@ pub async fn start(
                     )),
                 };
 
+                match &ctx.metadata {
+                    // quietly skipping delivery processes when there is no resolver.
+                    // (in case of a quarantine for example)
+                    Some(metadata) if metadata.resolver == "none" => {
+                        log::warn!(
+                            target: DELIVER,
+                            "delivery skipped due to NO_DELIVERY action call."
+                        );
+                        return Ok(());
+                    }
+                    _ => {}
+                };
+
                 Queue::Deliver.write_to_queue(config, &ctx)?;
 
                 delivery_sender

--- a/src/processes/mime.rs
+++ b/src/processes/mime.rs
@@ -69,8 +69,8 @@ pub async fn start(
             .add_data("metadata", ctx.metadata.clone());
 
         match rule_engine.run_when("postq") {
-            Status::Deny => Queue::Dead.write_to_queue(config, &ctx).await?,
-            Status::Block => Queue::Quarantine.write_to_queue(config, &ctx).await?,
+            Status::Deny => Queue::Dead.write_to_queue(config, &ctx)?,
+            Status::Block => Queue::Quarantine.write_to_queue(config, &ctx)?,
             _ => {
                 match rule_engine.get_scoped_envelop() {
                     Some((envelop, metadata, mail)) => {
@@ -84,7 +84,7 @@ pub async fn start(
                     )),
                 };
 
-                Queue::Deliver.write_to_queue(config, &ctx).await?;
+                Queue::Deliver.write_to_queue(config, &ctx)?;
 
                 delivery_sender
                     .send(ProcessMessage {

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -49,7 +49,7 @@ impl Queue {
     }
 
     /// write the email to a queue and send the message id to another process.
-    pub async fn write_to_queue(
+    pub fn write_to_queue(
         &self,
         config: &ServerConfig,
         ctx: &crate::model::mail::MailContext,

--- a/src/rules/actions.rs
+++ b/src/rules/actions.rs
@@ -47,6 +47,11 @@ pub(super) mod vsl {
         queue.enqueue(Operation::Block(path.to_string()))
     }
 
+    /// enqueue a quarantine operation on the queue.
+    pub fn op_quarantine(queue: &mut OperationQueue) {
+        queue.enqueue(Operation::Quarantine)
+    }
+
     /// enqueue a header mutation operation on the queue.
     pub fn op_mutate_header(queue: &mut OperationQueue, header: &str, value: &str) {
         queue.enqueue(Operation::MutateHeader(

--- a/src/rules/actions.rs
+++ b/src/rules/actions.rs
@@ -48,8 +48,8 @@ pub(super) mod vsl {
     }
 
     /// enqueue a quarantine operation on the queue.
-    pub fn op_quarantine(queue: &mut OperationQueue) {
-        queue.enqueue(Operation::Quarantine)
+    pub fn op_quarantine(queue: &mut OperationQueue, reason: String) {
+        queue.enqueue(Operation::Quarantine { reason })
     }
 
     /// enqueue a header mutation operation on the queue.

--- a/src/rules/currying.rhai
+++ b/src/rules/currying.rhai
@@ -123,8 +123,8 @@ let vsl = #{
 
     // put the email in the quarantine queue.
     // autmaticaly calls NO_DELIVERY.
-    QUARANTINE: || {
-        __OPERATION_QUEUE.op_quarantine();
+    QUARANTINE: |reason| {
+        __OPERATION_QUEUE.op_quarantine(reason);
         metadata.resolver = "none";
     },
 

--- a/src/rules/currying.rhai
+++ b/src/rules/currying.rhai
@@ -121,6 +121,10 @@ let vsl = #{
         __BLOCK()
     },
 
+    QUARANTINE: || {
+        __OPERATION_QUEUE.op_quarantine();
+    },
+
     // send a mail.
     MAIL: |from, to, subject, body| {
         __MAIL(from, to, subject, body);

--- a/src/rules/currying.rhai
+++ b/src/rules/currying.rhai
@@ -121,8 +121,11 @@ let vsl = #{
         __BLOCK()
     },
 
+    // put the email in the quarantine queue.
+    // autmaticaly calls NO_DELIVERY.
     QUARANTINE: || {
         __OPERATION_QUEUE.op_quarantine();
+        metadata.resolver = "none";
     },
 
     // send a mail.
@@ -147,5 +150,10 @@ let vsl = #{
     // set resolver to mbox (default mbox database format).
     USE_MBOX: || {
         metadata.resolver = "mbox";
+    },
+
+    // prevent the system to deliver the email.
+    NO_DELIVERY: || {
+        metadata.resolver = "none";
     },
 };

--- a/src/rules/operation_queue.rs
+++ b/src/rules/operation_queue.rs
@@ -29,6 +29,8 @@ pub enum Operation {
     MutateHeader(String, String),
     /// block an incoming email (blocked email directory)
     Block(String),
+    /// put an email in the quarantine queue.
+    Quarantine,
 }
 
 impl OperationQueue {

--- a/src/rules/operation_queue.rs
+++ b/src/rules/operation_queue.rs
@@ -30,7 +30,7 @@ pub enum Operation {
     /// block an incoming email (blocked email directory)
     Block(String),
     /// put an email in the quarantine queue.
-    Quarantine,
+    Quarantine { reason: String },
 }
 
 impl OperationQueue {

--- a/src/rules/rule_engine.rs
+++ b/src/rules/rule_engine.rs
@@ -204,10 +204,10 @@ impl<'a> RuleEngine<'a> {
                     std::io::Write::write_all(&mut file, serde_json::to_string(&ctx)?.as_bytes())?;
                     log::warn!(target: RULES, "'{message_id}' email blocked.");
                 }
-                Operation::Quarantine => {
+                Operation::Quarantine { reason } => {
                     log::warn!(
                         target: RULES,
-                        "'{}' email quarantined.",
+                        "'{}' email quarantined: {reason}.",
                         &ctx.metadata.as_ref().unwrap().message_id
                     );
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -222,7 +222,7 @@ impl ServerVSMTP {
                 crate::transaction::TransactionResult::Mail(mail) => {
                     helo_domain = Some(mail.envelop.helo.clone());
 
-                    match Queue::Working.write_to_queue(&conn.config, &mail).await {
+                    match Queue::Working.write_to_queue(&conn.config, &mail) {
                         Ok(_) => {
                             working_sender
                                 .send(ProcessMessage {
@@ -286,7 +286,7 @@ impl ServerVSMTP {
                             crate::transaction::TransactionResult::Mail(mail) => {
                                 secured_helo_domain = Some(mail.envelop.helo.clone());
 
-                                match Queue::Working.write_to_queue(&conn.config, &mail).await {
+                                match Queue::Working.write_to_queue(&conn.config, &mail) {
                                     Ok(_) => {
                                         working_sender
                                             .send(ProcessMessage {

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -229,7 +229,10 @@ impl Transaction<'_> {
                 }
 
                 // executing all registered extensive operations.
-                if let Err(error) = self.rule_engine.execute_operation_queue(&self.mail) {
+                if let Err(error) = self
+                    .rule_engine
+                    .execute_operation_queue(&conn.config, &self.mail)
+                {
                     log::error!(
                         target: RULES,
                         "failed to empty the operation queue: '{}'",


### PR DESCRIPTION
(please merge #101 first)

- Added the `vsl.QUARANTINE` action, enabling the user to put the email in the quarantine queue. Calling this action waits for the complete transaction of a mail to be done, write the email in the quarantine queue, and skips parsing & delivery.
- Added the `vsl.NO_DELIVERY` action, enabling the user to skip delivery.

Note that `Queue.write_to_queue` is no longer async, because we need it in a transaction to write quarantined emails and it messes up the lifetimes. There should be a way to make it async but I disabled it to code faster.

closes #60