### PR TITLE
More test on message parser

### DIFF
--- a/src/mime/tests/mail/mime1.eml
+++ b/src/mime/tests/mail/mime1.eml
@@ -1,0 +1,44 @@
+From: "Sender Name" <sender@example.com>
+To: recipient@example.com
+Subject: Customer service contact info
+Date: Fri, 21 Nov 1997 09:55:06 -0600
+MIME-Version: 1.0
+Content-Type: multipart/mixed;
+    boundary="a3f166a86b56ff6c37755292d690675717ea3cd9de81228ec2b76ed4a15d6d1a"
+
+--a3f166a86b56ff6c37755292d690675717ea3cd9de81228ec2b76ed4a15d6d1a
+Content-Type: multipart/alternative;
+    boundary="sub_a3f166a86b56ff6c37755292d690675717ea3cd9de81228ec2b76ed4a15d6d1a"
+
+--sub_a3f166a86b56ff6c37755292d690675717ea3cd9de81228ec2b76ed4a15d6d1a
+Content-Type: text/plain; charset=iso-8859-1
+Content-Transfer-Encoding: quoted-printable
+
+Please see the attached file for a list of customers to contact.
+
+--sub_a3f166a86b56ff6c37755292d690675717ea3cd9de81228ec2b76ed4a15d6d1a
+Content-Type: text/html; charset=iso-8859-1
+Content-Transfer-Encoding: quoted-printable
+
+<html>
+<head></head>
+<body>
+<h1>Hello!</h1>
+<p>Please see the attached file for a list of customers to contact.</p>
+</body>
+</html>
+
+--sub_a3f166a86b56ff6c37755292d690675717ea3cd9de81228ec2b76ed4a15d6d1a--
+
+--a3f166a86b56ff6c37755292d690675717ea3cd9de81228ec2b76ed4a15d6d1a
+Content-Type: text/plain; name="customers.txt"
+Content-Description: customers.txt
+Content-Disposition: attachment;filename="customers.txt";
+    creation-date="Sat, 05 Aug 2017 19:35:36 GMT";
+Content-Transfer-Encoding: base64
+
+SUQsRmlyc3ROYW1lLExhc3ROYW1lLENvdW50cnkKMzQ4LEpvaG4sU3RpbGVzLENhbmFkYQo5MjM4
+OSxKaWUsTGl1LENoaW5hCjczNCxTaGlybGV5LFJvZHJpZ3VleixVbml0ZWQgU3RhdGVzCjI4OTMs
+QW5heWEsSXllbmdhcixJbmRpYQ==
+
+--a3f166a86b56ff6c37755292d690675717ea3cd9de81228ec2b76ed4a15d6d1a--

--- a/src/mime/tests/mail/rfc5322/A.1.1.a.eml
+++ b/src/mime/tests/mail/rfc5322/A.1.1.a.eml
@@ -1,0 +1,8 @@
+From: John Doe <jdoe@machine.example>
+To: Mary Smith <mary@example.net>
+Subject: Saying Hello
+Date: Fri, 21 Nov 1997 09:55:06 -0600
+Message-ID: <1234@local.machine.example>
+
+This is a message just to say hello.
+So, "Hello".

--- a/src/mime/tests/mail/rfc5322/A.1.1.b.eml
+++ b/src/mime/tests/mail/rfc5322/A.1.1.b.eml
@@ -1,0 +1,9 @@
+From: John Doe <jdoe@machine.example>
+Sender: Michael Jones <mjones@machine.example>
+To: Mary Smith <mary@example.net>
+Subject: Saying Hello
+Date: Fri, 21 Nov 1997 09:55:06 -0600
+Message-ID: <1234@local.machine.example>
+
+This is a message just to say hello.
+So, "Hello".

--- a/src/mime/tests/mail/rfc5322/A.1.2.eml
+++ b/src/mime/tests/mail/rfc5322/A.1.2.eml
@@ -1,0 +1,7 @@
+From: "Joe Q. Public" <john.q.public@example.com>
+To: Mary Smith <mary@x.test>, jdoe@example.org, Who? <one@y.test>
+Cc: <boss@nil.test>, "Giant; \"Big\" Box" <sysservices@example.net>
+Date: Tue, 1 Jul 2003 10:52:37 +0200
+Message-ID: <5678.21-Nov-1997@example.com>
+
+Hi everyone.

--- a/src/mime/tests/mail/rfc5322/A.1.3.eml
+++ b/src/mime/tests/mail/rfc5322/A.1.3.eml
@@ -1,0 +1,7 @@
+From: Pete <pete@silly.example>
+To: A Group:Ed Jones <c@a.test>,joe@where.test,John <jdoe@one.test>;
+Cc: Undisclosed recipients:;
+Date: Thu, 13 Feb 1969 23:32:54 -0330
+Message-ID: <testabcd.1234@silly.example>
+
+Testing.

--- a/src/mime/tests/mail/rfc5322/A.2.a.eml
+++ b/src/mime/tests/mail/rfc5322/A.2.a.eml
@@ -1,0 +1,8 @@
+From: John Doe <jdoe@machine.example>
+To: Mary Smith <mary@example.net>
+Subject: Saying Hello
+Date: Fri, 21 Nov 1997 09:55:06 -0600
+Message-ID: <1234@local.machine.example>
+
+This is a message just to say hello.
+So, "Hello".

--- a/src/mime/tests/mail/rfc5322/A.2.b.eml
+++ b/src/mime/tests/mail/rfc5322/A.2.b.eml
@@ -1,0 +1,10 @@
+From: Mary Smith <mary@example.net>
+To: John Doe <jdoe@machine.example>
+Reply-To: "Mary Smith: Personal Account" <smith@home.example>
+Subject: Re: Saying Hello
+Date: Fri, 21 Nov 1997 10:01:10 -0600
+Message-ID: <3456@example.net>
+In-Reply-To: <1234@local.machine.example>
+References: <1234@local.machine.example>
+
+This is a reply to your hello.

--- a/src/mime/tests/mail/rfc5322/A.2.c.eml
+++ b/src/mime/tests/mail/rfc5322/A.2.c.eml
@@ -1,0 +1,9 @@
+To: "Mary Smith: Personal Account" <smith@home.example>
+From: John Doe <jdoe@machine.example>
+Subject: Re: Saying Hello
+Date: Fri, 21 Nov 1997 11:00:00 -0600
+Message-ID: <abcd.1234@local.machine.test>
+In-Reply-To: <3456@example.net>
+References: <1234@local.machine.example> <3456@example.net>
+
+This is a reply to your reply.

--- a/src/mime/tests/mail/rfc5322/A.3.eml
+++ b/src/mime/tests/mail/rfc5322/A.3.eml
@@ -1,0 +1,12 @@
+Resent-From: Mary Smith <mary@example.net>
+Resent-To: Jane Brown <j-brown@other.example>
+Resent-Date: Mon, 24 Nov 1997 14:22:01 -0800
+Resent-Message-ID: <78910@example.net>
+From: John Doe <jdoe@machine.example>
+To: Mary Smith <mary@example.net>
+Subject: Saying Hello
+Date: Fri, 21 Nov 1997 09:55:06 -0600
+Message-ID: <1234@local.machine.example>
+
+This is a message just to say hello.
+So, "Hello".

--- a/src/mime/tests/mail/rfc5322/A.4.eml
+++ b/src/mime/tests/mail/rfc5322/A.4.eml
@@ -1,0 +1,15 @@
+Received: from x.y.test
+  by example.net
+  via TCP
+  with ESMTP
+  id ABC12345
+  for <mary@example.net>;  21 Nov 1997 10:05:43 -0600
+Received: from node.example by x.y.test; 21 Nov 1997 10:01:22 -0600
+From: John Doe <jdoe@node.example>
+To: Mary Smith <mary@example.net>
+Subject: Saying Hello
+Date: Fri, 21 Nov 1997 09:55:06 -0600
+Message-ID: <1234@local.node.example>
+
+This is a message just to say hello.
+So, "Hello".

--- a/src/mime/tests/mail/rfc5322/A.5.eml
+++ b/src/mime/tests/mail/rfc5322/A.5.eml
@@ -1,0 +1,15 @@
+From: Pete(A nice \) chap) <pete(his account)@silly.test(his host)>
+To:A Group(Some people)
+     :Chris Jones <c@(Chris's host.)public.example>,
+         joe@example.org,
+  John <jdoe@one.test> (my dear friend); (the end of the group)
+Cc:(Empty list)(start)Hidden recipients  :(nobody(that I know))  ;
+Date: Thu,
+      13
+        Feb
+          1969
+      23:32
+               -0330 (Newfoundland Time)
+Message-ID:              <testabcd.1234@silly.test>
+
+Testing.

--- a/src/mime/tests/mime_parser/allen_p__discussion_threads__1.rs
+++ b/src/mime/tests/mime_parser/allen_p__discussion_threads__1.rs
@@ -27,71 +27,71 @@ const MAIL: &str = include_str!("../mail/allen-p__discussion_threads__1.eml");
 
 #[test]
 fn mime_parser() {
-    match MailMimeParser::default().parse(MAIL.as_bytes()) {
-        Ok(mail) => {
-            assert_eq!(
-                mail,
-                Mail {
-                    headers: vec![
-                        (
-                            "message-id",
-                            "<20379972.1075855673249.JavaMail.evans@thyme>"
-                        ),
-                        ("date", "Fri, 10 Dec 1999 07:00:00 -0800 "),
-                        ("from", "phillip.allen@enron.com"),
-                        ("to", "naomi.johnston@enron.com"),
-                        ("subject", ""),
-                        ("mime-version", "1.0"),
-                        ("x-from", "Phillip K Allen"),
-                        ("x-to", "Naomi Johnston"),
-                        ("x-cc", ""),
-                        ("x-bcc", ""),
-                        ("x-folder", "\\Phillip_Allen_Dec2000\\Notes Folders\\Discussion threads"),
-                        ("x-origin", "Allen-P"),
-                        ("x-filename", "pallen.nsf"),
-                    ]
+    assert_eq!(
+        MailMimeParser::default().parse(MAIL.as_bytes()).unwrap(),
+        Mail {
+            headers: vec![
+                (
+                    "message-id",
+                    "<20379972.1075855673249.JavaMail.evans@thyme>"
+                ),
+                ("date", "Fri, 10 Dec 1999 07:00:00 -0800 "),
+                ("from", "phillip.allen@enron.com"),
+                ("to", "naomi.johnston@enron.com"),
+                ("subject", ""),
+                ("mime-version", "1.0"),
+                ("x-from", "Phillip K Allen"),
+                ("x-to", "Naomi Johnston"),
+                ("x-cc", ""),
+                ("x-bcc", ""),
+                (
+                    "x-folder",
+                    "\\Phillip_Allen_Dec2000\\Notes Folders\\Discussion threads"
+                ),
+                ("x-origin", "Allen-P"),
+                ("x-filename", "pallen.nsf"),
+            ]
+            .into_iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect::<Vec<_>>(),
+            body: BodyType::Mime(Box::new(Mime {
+                headers: vec![
+                    MimeHeader {
+                        name: "content-type".to_string(),
+                        value: "text/plain".to_string(),
+                        args: collection! {
+                            "charset".to_string() => "us-ascii".to_string()
+                        }
+                    },
+                    MimeHeader {
+                        name: "content-transfer-encoding".to_string(),
+                        value: "7bit".to_string(),
+                        args: collection! {}
+                    },
+                ],
+                content: MimeBodyType::Regular(
+                    vec![
+                    "Naomi,",
+                    "",
+                    "The two analysts that I have had contact with are Matt Lenhart  and Vishal ",
+                    "Apte.",
+                    "Matt will be represented by Jeff Shankman.",
+                    "Vishal joined our group in October.  He was in the Power Trading Group for ",
+                    "the first 9 months.",
+                    "I spoke to Jim Fallon and we agreed that he should be in the excellent ",
+                    "category.  I just don't want Vishal ",
+                    "to go unrepresented since he changed groups mid year.",
+                    "",
+                    "Call me with questions.(x37041)",
+                    "",
+                    "Phillip Allen",
+                    "West Gas Trading",
+                ]
                     .into_iter()
-                    .map(|(k, v)| (k.to_string(), v.to_string()))
-                    .collect::<Vec<_>>(),
-                    body: BodyType::Mime(Box::new(Mime {
-                        headers: vec![
-                            MimeHeader{
-                                name: "content-type".to_string(),
-                                value: "text/plain".to_string(),
-                                args: collection! {
-                                    "charset".to_string() => "us-ascii".to_string()
-                                }
-                            },
-                            MimeHeader{
-                                name: "content-transfer-encoding".to_string(),
-                                value: "7bit".to_string(),
-                                args: collection! {
-                                }
-                            },
-                        ],
-                        content: MimeBodyType::Regular(vec![
-                            "Naomi,",
-                            "",
-                            "The two analysts that I have had contact with are Matt Lenhart  and Vishal ",
-                            "Apte.",
-                            "Matt will be represented by Jeff Shankman.",
-                            "Vishal joined our group in October.  He was in the Power Trading Group for ",
-                            "the first 9 months.",
-                            "I spoke to Jim Fallon and we agreed that he should be in the excellent ",
-                            "category.  I just don't want Vishal ",
-                            "to go unrepresented since he changed groups mid year.",
-                            "",
-                            "Call me with questions.(x37041)",
-                            "",
-                            "Phillip Allen",
-                            "West Gas Trading",
-                        ].into_iter().map(str::to_string).collect::<Vec<_>>())
-                    }))
-                }
-            )
+                    .map(str::to_string)
+                    .collect::<Vec<_>>()
+                )
+            }))
         }
-        Err(e) => {
-            panic!("failed because '{}'", e);
-        }
-    }
+    );
 }

--- a/src/mime/tests/mime_parser/mime1.rs
+++ b/src/mime/tests/mime_parser/mime1.rs
@@ -1,0 +1,144 @@
+use crate::mime::{
+    mail::{BodyType, Mail},
+    mime_type::{Mime, MimeBodyType, MimeHeader, MimeMultipart},
+    parser::MailMimeParser,
+};
+
+const MAIL: &str = include_str!("../mail/mime1.eml");
+
+#[test]
+fn mime_parser() {
+    assert_eq!(
+        MailMimeParser::default().parse(MAIL.as_bytes()).unwrap(),
+        Mail { headers:
+            vec![
+                ("from", "\"Sender Name\" <sender@example.com>"),
+                ("to", "recipient@example.com"),
+                ("subject", "Customer service contact info"),
+                ("date", "Fri, 21 Nov 1997 09:55:06 -0600"),
+                ("mime-version", "1.0")
+            ].into_iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect::<Vec<_>>(),
+        body: BodyType::Mime(Box::new(Mime {
+            headers: vec![
+                MimeHeader {
+                    name: "content-type".to_string(),
+                    value: "multipart/mixed".to_string(),
+                    args: crate::collection!{
+                        "boundary".to_string() =>
+                        "a3f166a86b56ff6c37755292d690675717ea3cd9de81228ec2b76ed4a15d6d1a".to_string()
+                    }
+                }
+            ],
+            content: MimeBodyType::Multipart(MimeMultipart {
+                preamble: "".to_string(),
+                parts: vec![
+                    Mime {
+                        headers: vec![
+                            MimeHeader {
+                                name: "content-type".to_string(),
+                                value: "multipart/alternative".to_string(),
+                                args: crate::collection!{
+                                    "boundary".to_string() =>
+                                    "sub_a3f166a86b56ff6c37755292d690675717ea3cd9de81228ec2b76ed4a15d6d1a".to_string()
+                                }
+                            }
+                        ],
+                        content: MimeBodyType::Multipart(MimeMultipart {
+                            preamble: "".to_string(),
+                            parts: vec![
+                                Mime {
+                                    headers: vec![
+                                        MimeHeader {
+                                            name: "content-type".to_string(),
+                                            value: "text/plain".to_string(),
+                                            args: crate::collection!{
+                                                "charset".to_string() => "iso-8859-1".to_string()
+                                            }
+                                        },
+                                        MimeHeader {
+                                            name: "content-transfer-encoding".to_string(),
+                                            value: "quoted-printable".to_string(),
+                                            args: crate::collection!{}
+                                        }
+                                    ],
+                                    content: MimeBodyType::Regular(vec![
+                                        "",
+                                        "Please see the attached file for a list of customers to contact.",
+                                        ""
+                                    ].into_iter().map(str::to_string).collect::<_>())
+                                },
+                                Mime {
+                                    headers: vec![
+                                        MimeHeader {
+                                            name: "content-type".to_string(),
+                                            value: "text/html".to_string(),
+                                            args: crate::collection!{
+                                                "charset".to_string() => "iso-8859-1".to_string()
+                                            }
+                                        },
+                                        MimeHeader {
+                                            name: "content-transfer-encoding".to_string(),
+                                            value: "quoted-printable".to_string(),
+                                            args: crate::collection!{}
+                                        }
+                                    ],
+                                    content: MimeBodyType::Regular(vec![
+                                        "",
+                                        "<html>",
+                                        "<head></head>",
+                                        "<body>",
+                                        "<h1>Hello!</h1>",
+                                        "<p>Please see the attached file for a list of customers to contact.</p>",
+                                        "</body>",
+                                        "</html>",
+                                        ""
+                                    ].into_iter().map(str::to_string).collect::<_>())
+                                }
+                            ],
+                            epilogue: "".to_string()
+                        })
+                    },
+                    Mime {
+                        headers: vec![
+                            MimeHeader {
+                                name: "content-type".to_string(),
+                                value: "text/plain".to_string(),
+                                args: crate::collection!{
+                                    "name".to_string() => "customers.txt".to_string()
+                                }
+                            },
+                            MimeHeader {
+                                name: "content-description".to_string(),
+                                value: "customers.txt".to_string(),
+                                args: crate::collection!{}
+                            },
+                            MimeHeader {
+                                name: "content-disposition".to_string(),
+                                value: "attachment".to_string(),
+                                args: crate::collection!{
+                                    "filename".to_string() => "customers.txt".to_string(),
+                                    "creation-date".to_string() => "Sat, 05 Aug 2017 19:35:36 GMT".to_string()
+                                }
+                            },
+                            MimeHeader {
+                                name: "content-transfer-encoding".to_string(),
+                                value: "base64".to_string(),
+                                args: crate::collection!{}
+                            }
+                        ],
+                        content: MimeBodyType::Regular(vec![
+                            "",
+                            "SUQsRmlyc3ROYW1lLExhc3ROYW1lLENvdW50cnkKMzQ4LEpvaG4sU3RpbGVzLENhbmFkYQo5MjM4",
+                            "OSxKaWUsTGl1LENoaW5hCjczNCxTaGlybGV5LFJvZHJpZ3VleixVbml0ZWQgU3RhdGVzCjI4OTMs",
+                            "QW5heWEsSXllbmdhcixJbmRpYQ==",
+                            ""
+                        ].into_iter().map(str::to_string).collect::<_>())
+                    }],
+                    epilogue: "".to_string()
+                })
+            }))
+        }
+    );
+}

--- a/src/mime/tests/mime_parser/rfc5322/a_1_1.rs
+++ b/src/mime/tests/mime_parser/rfc5322/a_1_1.rs
@@ -1,0 +1,59 @@
+use crate::mime::{
+    mail::{BodyType, Mail},
+    parser::MailMimeParser,
+};
+
+#[test]
+fn simple() {
+    assert_eq!(
+        MailMimeParser::default()
+            .parse(include_str!("../../mail/rfc5322/A.1.1.a.eml").as_bytes())
+            .unwrap(),
+        Mail {
+            headers: vec![
+                ("from", "John Doe <jdoe@machine.example>"),
+                ("to", "Mary Smith <mary@example.net>"),
+                ("subject", "Saying Hello"),
+                ("date", "Fri, 21 Nov 1997 09:55:06 -0600"),
+                ("message-id", "<1234@local.machine.example>"),
+            ]
+            .into_iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect::<Vec<_>>(),
+            body: BodyType::Regular(
+                vec!["This is a message just to say hello.", "So, \"Hello\"."]
+                    .into_iter()
+                    .map(str::to_string)
+                    .collect::<_>()
+            )
+        }
+    );
+}
+
+#[test]
+fn forward() {
+    assert_eq!(
+        MailMimeParser::default()
+            .parse(include_str!("../../mail/rfc5322/A.1.1.b.eml").as_bytes())
+            .unwrap(),
+        Mail {
+            headers: vec![
+                ("from", "John Doe <jdoe@machine.example>"),
+                ("sender", "Michael Jones <mjones@machine.example>"),
+                ("to", "Mary Smith <mary@example.net>"),
+                ("subject", "Saying Hello"),
+                ("date", "Fri, 21 Nov 1997 09:55:06 -0600"),
+                ("message-id", "<1234@local.machine.example>"),
+            ]
+            .into_iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect::<Vec<_>>(),
+            body: BodyType::Regular(
+                vec!["This is a message just to say hello.", "So, \"Hello\"."]
+                    .into_iter()
+                    .map(str::to_string)
+                    .collect::<_>()
+            )
+        }
+    );
+}

--- a/src/mime/tests/mime_parser/rfc5322/a_1_2.rs
+++ b/src/mime/tests/mime_parser/rfc5322/a_1_2.rs
@@ -1,0 +1,37 @@
+use crate::mime::{
+    mail::{BodyType, Mail},
+    parser::MailMimeParser,
+};
+
+const MAIL: &str = include_str!("../../mail/rfc5322/A.1.2.eml");
+
+#[test]
+fn types_mailboxes() {
+    assert_eq!(
+        MailMimeParser::default().parse(MAIL.as_bytes()).unwrap(),
+        Mail {
+            headers: vec![
+                ("from", "\"Joe Q. Public\" <john.q.public@example.com>"),
+                (
+                    "to",
+                    "Mary Smith <mary@x.test>, jdoe@example.org, Who? <one@y.test>"
+                ),
+                (
+                    "cc",
+                    "<boss@nil.test>, \"Giant; \\\"Big\\\" Box\" <sysservices@example.net>"
+                ),
+                ("date", "Tue, 1 Jul 2003 10:52:37 +0200"),
+                ("message-id", "<5678.21-Nov-1997@example.com>"),
+            ]
+            .into_iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect::<Vec<_>>(),
+            body: BodyType::Regular(
+                vec!["Hi everyone."]
+                    .into_iter()
+                    .map(str::to_string)
+                    .collect::<_>()
+            )
+        }
+    );
+}

--- a/src/mime/tests/mime_parser/rfc5322/a_1_3.rs
+++ b/src/mime/tests/mime_parser/rfc5322/a_1_3.rs
@@ -1,0 +1,34 @@
+use crate::mime::{
+    mail::{BodyType, Mail},
+    parser::MailMimeParser,
+};
+
+const MAIL: &str = include_str!("../../mail/rfc5322/A.1.3.eml");
+
+#[test]
+fn group_addresses() {
+    assert_eq!(
+        MailMimeParser::default().parse(MAIL.as_bytes()).unwrap(),
+        Mail {
+            headers: vec![
+                ("from", "Pete <pete@silly.example>"),
+                (
+                    "to",
+                    "A Group:Ed Jones <c@a.test>,joe@where.test,John <jdoe@one.test>;"
+                ),
+                ("cc", "Undisclosed recipients:;"),
+                ("date", "Thu, 13 Feb 1969 23:32:54 -0330"),
+                ("message-id", "<testabcd.1234@silly.example>"),
+            ]
+            .into_iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect::<Vec<_>>(),
+            body: BodyType::Regular(
+                vec!["Testing."]
+                    .into_iter()
+                    .map(str::to_string)
+                    .collect::<_>()
+            )
+        }
+    );
+}

--- a/src/mime/tests/mime_parser/rfc5322/a_2.rs
+++ b/src/mime/tests/mime_parser/rfc5322/a_2.rs
@@ -1,0 +1,99 @@
+use crate::mime::{
+    mail::{BodyType, Mail},
+    parser::MailMimeParser,
+};
+
+#[test]
+fn simple() {
+    assert_eq!(
+        MailMimeParser::default()
+            .parse(include_str!("../../mail/rfc5322/A.2.a.eml").as_bytes())
+            .unwrap(),
+        Mail {
+            headers: vec![
+                ("from", "John Doe <jdoe@machine.example>"),
+                ("to", "Mary Smith <mary@example.net>"),
+                ("subject", "Saying Hello"),
+                ("date", "Fri, 21 Nov 1997 09:55:06 -0600"),
+                ("message-id", "<1234@local.machine.example>"),
+            ]
+            .into_iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect::<Vec<_>>(),
+            body: BodyType::Regular(
+                vec!["This is a message just to say hello.", "So, \"Hello\"."]
+                    .into_iter()
+                    .map(str::to_string)
+                    .collect::<_>()
+            )
+        }
+    );
+}
+
+#[test]
+fn reply_simple() {
+    assert_eq!(
+        MailMimeParser::default()
+            .parse(include_str!("../../mail/rfc5322/A.2.b.eml").as_bytes())
+            .unwrap(),
+        Mail {
+            headers: vec![
+                ("from", "Mary Smith <mary@example.net>"),
+                ("to", "John Doe <jdoe@machine.example>"),
+                (
+                    "reply-to",
+                    "\"Mary Smith: Personal Account\" <smith@home.example>"
+                ),
+                ("subject", "Re: Saying Hello"),
+                ("date", "Fri, 21 Nov 1997 10:01:10 -0600"),
+                ("message-id", "<3456@example.net>"),
+                ("in-reply-to", "<1234@local.machine.example>"),
+                ("references", "<1234@local.machine.example>"),
+            ]
+            .into_iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect::<Vec<_>>(),
+            body: BodyType::Regular(
+                vec!["This is a reply to your hello."]
+                    .into_iter()
+                    .map(str::to_string)
+                    .collect::<_>()
+            )
+        }
+    );
+}
+
+#[test]
+fn reply_reply() {
+    assert_eq!(
+        MailMimeParser::default()
+            .parse(include_str!("../../mail/rfc5322/A.2.c.eml").as_bytes())
+            .unwrap(),
+        Mail {
+            headers: vec![
+                (
+                    "to",
+                    "\"Mary Smith: Personal Account\" <smith@home.example>"
+                ),
+                ("from", "John Doe <jdoe@machine.example>"),
+                ("subject", "Re: Saying Hello"),
+                ("date", "Fri, 21 Nov 1997 11:00:00 -0600"),
+                ("message-id", "<abcd.1234@local.machine.test>"),
+                ("in-reply-to", "<3456@example.net>"),
+                (
+                    "references",
+                    "<1234@local.machine.example> <3456@example.net>"
+                ),
+            ]
+            .into_iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect::<Vec<_>>(),
+            body: BodyType::Regular(
+                vec!["This is a reply to your reply."]
+                    .into_iter()
+                    .map(str::to_string)
+                    .collect::<_>()
+            )
+        }
+    );
+}

--- a/src/mime/tests/mime_parser/rfc5322/a_3.rs
+++ b/src/mime/tests/mime_parser/rfc5322/a_3.rs
@@ -1,0 +1,35 @@
+use crate::mime::{
+    mail::{BodyType, Mail},
+    parser::MailMimeParser,
+};
+
+#[test]
+fn resent() {
+    assert_eq!(
+        MailMimeParser::default()
+            .parse(include_str!("../../mail/rfc5322/A.3.eml").as_bytes())
+            .unwrap(),
+        Mail {
+            headers: vec![
+                ("resent-from", "Mary Smith <mary@example.net>"),
+                ("resent-to", "Jane Brown <j-brown@other.example>"),
+                ("resent-date", "Mon, 24 Nov 1997 14:22:01 -0800"),
+                ("resent-message-id", "<78910@example.net>"),
+                ("from", "John Doe <jdoe@machine.example>"),
+                ("to", "Mary Smith <mary@example.net>"),
+                ("subject", "Saying Hello"),
+                ("date", "Fri, 21 Nov 1997 09:55:06 -0600"),
+                ("message-id", "<1234@local.machine.example>"),
+            ]
+            .into_iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect::<Vec<_>>(),
+            body: BodyType::Regular(
+                vec!["This is a message just to say hello.", "So, \"Hello\"."]
+                    .into_iter()
+                    .map(str::to_string)
+                    .collect::<_>()
+            )
+        }
+    );
+}

--- a/src/mime/tests/mime_parser/rfc5322/a_4.rs
+++ b/src/mime/tests/mime_parser/rfc5322/a_4.rs
@@ -1,0 +1,46 @@
+use crate::mime::{
+    mail::{BodyType, Mail},
+    parser::MailMimeParser,
+};
+
+#[test]
+fn tracing() {
+    assert_eq!(
+        MailMimeParser::default()
+            .parse(include_str!("../../mail/rfc5322/A.4.eml").as_bytes())
+            .unwrap(),
+        Mail {
+            headers: vec![
+                (
+                    "received",
+                    concat!(
+                        "from x.y.test",
+                        "  by example.net",
+                        "  via TCP",
+                        "  with ESMTP",
+                        "  id ABC12345",
+                        "  for <mary@example.net>;  21 Nov 1997 10:05:43 -0600",
+                    )
+                ),
+                (
+                    "received",
+                    "from node.example by x.y.test; 21 Nov 1997 10:01:22 -0600"
+                ),
+                ("from", "John Doe <jdoe@node.example>"),
+                ("to", "Mary Smith <mary@example.net>"),
+                ("subject", "Saying Hello"),
+                ("date", "Fri, 21 Nov 1997 09:55:06 -0600"),
+                ("message-id", "<1234@local.node.example>"),
+            ]
+            .into_iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect::<Vec<_>>(),
+            body: BodyType::Regular(
+                vec!["This is a message just to say hello.", "So, \"Hello\"."]
+                    .into_iter()
+                    .map(str::to_string)
+                    .collect::<_>()
+            )
+        }
+    );
+}

--- a/src/mime/tests/mime_parser/rfc5322/a_5.rs
+++ b/src/mime/tests/mime_parser/rfc5322/a_5.rs
@@ -3,12 +3,7 @@ use crate::mime::{
     parser::MailMimeParser,
 };
 
-// FIXME: this one is not passing :
-// issue for escape parenthesis in comment :
-// `hello(foo \) bar) world` => `hello world`
-
 #[test]
-#[ignore]
 fn white_space_and_comments() {
     assert_eq!(
         MailMimeParser::default()

--- a/src/mime/tests/mime_parser/rfc5322/a_5.rs
+++ b/src/mime/tests/mime_parser/rfc5322/a_5.rs
@@ -1,0 +1,54 @@
+use crate::mime::{
+    mail::{BodyType, Mail},
+    parser::MailMimeParser,
+};
+
+// FIXME: this one is not passing :
+// issue for escape parenthesis in comment :
+// `hello(foo \) bar) world` => `hello world`
+
+#[test]
+#[ignore]
+fn white_space_and_comments() {
+    assert_eq!(
+        MailMimeParser::default()
+            .parse(include_str!("../../mail/rfc5322/A.5.eml").as_bytes())
+            .unwrap(),
+        Mail {
+            headers: vec![
+                ("from", "Pete <pete@silly.test>"),
+                (
+                    "to",
+                    concat!(
+                        "A Group",
+                        "     :Chris Jones <c@public.example>,",
+                        "         joe@example.org,",
+                        "  John <jdoe@one.test> ; ",
+                    )
+                ),
+                ("cc", "Hidden recipients  :  ;"),
+                (
+                    "date",
+                    concat!(
+                        "Thu,",
+                        "      13",
+                        "        Feb",
+                        "          1969",
+                        "      23:32",
+                        "               -0330 "
+                    )
+                ),
+                ("message-id", "<testabcd.1234@silly.test>"),
+            ]
+            .into_iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect::<Vec<_>>(),
+            body: BodyType::Regular(
+                vec!["Testing."]
+                    .into_iter()
+                    .map(str::to_string)
+                    .collect::<_>()
+            )
+        }
+    );
+}

--- a/src/mime/tests/mime_parser/rfc5322/mod.rs
+++ b/src/mime/tests/mime_parser/rfc5322/mod.rs
@@ -1,0 +1,7 @@
+mod a_1_1;
+mod a_1_2;
+mod a_1_3;
+mod a_2;
+mod a_3;
+mod a_4;
+mod a_5;

--- a/src/mime/tests/mod.rs
+++ b/src/mime/tests/mod.rs
@@ -23,6 +23,8 @@ pub mod mime_parser {
     #[allow(non_snake_case)]
     mod allen_p__discussion_threads__1;
 
+    mod mime1;
+
     fn visit_dirs(
         dir: &std::path::Path,
         cb: &dyn Fn(&std::fs::DirEntry) -> std::io::Result<()>,

--- a/src/mime/tests/mod.rs
+++ b/src/mime/tests/mod.rs
@@ -58,14 +58,17 @@ pub mod mime_parser {
                     .open("tmp/generated/output.txt")
                     .unwrap();
 
-                let mail = std::fs::read_to_string(entry.path()).map_err(|e| {
-                    std::io::Write::write(
-                        &mut output,
-                        format!("reading failed: '{:?}' error: '{}'\n", entry.path(), e).as_bytes(),
-                    )
+                let mail = std::fs::read_to_string(entry.path())
+                    .map_err(|e| {
+                        std::io::Write::write(
+                            &mut output,
+                            format!("reading failed: '{:?}' error: '{}'\n", entry.path(), e)
+                                .as_bytes(),
+                        )
+                        .unwrap();
+                        e
+                    })
                     .unwrap();
-                    e
-                })?;
 
                 MailMimeParser::default()
                     .parse(mail.as_bytes())

--- a/src/mime/tests/mod.rs
+++ b/src/mime/tests/mod.rs
@@ -18,6 +18,8 @@
 pub mod mime_parser {
     use crate::mime::parser::MailMimeParser;
 
+    mod rfc5322;
+
     #[allow(non_snake_case)]
     mod allen_p__discussion_threads__1;
 


### PR DESCRIPTION
* add simple test from rfc 5322
* update "remove_comments" to support escaped parenthesis within comments
* adding on mail with nested boundary