### PR TITLE
Fork on start of vSMTP

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -99,7 +99,7 @@ jobs:
   bench:
     runs-on: ubuntu-latest
     needs: test
-    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/develop'
+    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop'
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v1

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -31,6 +31,7 @@
         "roadmap",
         "Rset",
         "rustls",
+        "setgid",
         "setuid",
         "SMTPS",
         "SMTPUTF",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,7 @@ tokio = { version = "1.16.1", features = [
 
 num_cpus = "1.13.1"
 wait-timeout = "0.2.0"
+fork = "0.1.18"
 
 [dev-dependencies]
 criterion = { version = "0.3.5", features = ["async_tokio"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,6 @@ tokio = { version = "1.16.1", features = [
 
 num_cpus = "1.13.1"
 wait-timeout = "0.2.0"
-fork = "0.1.18"
 
 [dev-dependencies]
 criterion = { version = "0.3.5", features = ["async_tokio"] }

--- a/benches/receiver.rs
+++ b/benches/receiver.rs
@@ -41,7 +41,7 @@ impl Resolver for DefaultResolverTest {
 fn get_test_config() -> std::sync::Arc<ServerConfig> {
     std::sync::Arc::new(
         ServerConfig::builder()
-            .with_rfc_port("bench.server.com", "foo", None)
+            .with_rfc_port("bench.server.com", "foo", "foo", None)
             .without_log()
             .without_smtps()
             .with_default_smtp()

--- a/benches/receiver.rs
+++ b/benches/receiver.rs
@@ -41,7 +41,7 @@ impl Resolver for DefaultResolverTest {
 fn get_test_config() -> std::sync::Arc<ServerConfig> {
     std::sync::Arc::new(
         ServerConfig::builder()
-            .with_rfc_port("bench.server.com", None)
+            .with_rfc_port("bench.server.com", "foo", None)
             .without_log()
             .without_smtps()
             .with_default_smtp()

--- a/config/vsmtp.dev-local.toml
+++ b/config/vsmtp.dev-local.toml
@@ -4,6 +4,8 @@ addr = "0.0.0.0:10025"
 addr_submission = "0.0.0.0:10587"
 addr_submissions = "0.0.0.0:10465"
 thread_count = 10
+vsmtp_user = "vsmtp"
+vsmtp_group = "vsmtp"
 
 [logs]
 file = "./tmp/var/log/vsmtp/vsmtp.log"

--- a/example/antivirus/vsmtp.toml
+++ b/example/antivirus/vsmtp.toml
@@ -1,5 +1,7 @@
 [server]
 domain = "testserver.com"
+vsmtp_user = "vsmtp"
+vsmtp_group = "vsmtp"
 
 [logs]
 

--- a/src/config/config_builder.rs
+++ b/src/config/config_builder.rs
@@ -45,6 +45,7 @@ impl ServerConfig {
 pub struct WantsServer(pub(crate) ());
 
 impl ConfigBuilder<WantsServer> {
+    #[allow(clippy::too_many_arguments)]
     pub fn with_server(
         self,
         domain: impl Into<String>,

--- a/src/config/config_builder.rs
+++ b/src/config/config_builder.rs
@@ -49,6 +49,7 @@ impl ConfigBuilder<WantsServer> {
         self,
         domain: impl Into<String>,
         vsmtp_user: impl Into<String>,
+        vsmtp_group: impl Into<String>,
         addr: std::net::SocketAddr,
         addr_submission: std::net::SocketAddr,
         addr_submissions: std::net::SocketAddr,
@@ -64,6 +65,7 @@ impl ConfigBuilder<WantsServer> {
                     addr_submissions,
                     thread_count,
                     vsmtp_user: vsmtp_user.into(),
+                    vsmtp_group: vsmtp_group.into(),
                 },
             },
         }
@@ -73,11 +75,13 @@ impl ConfigBuilder<WantsServer> {
         self,
         domain: impl Into<String>,
         vsmtp_user: impl Into<String>,
+        vsmtp_group: impl Into<String>,
         thread_count: Option<usize>,
     ) -> ConfigBuilder<WantsLogging> {
         self.with_server(
             domain,
             vsmtp_user,
+            vsmtp_group,
             "0.0.0.0:25".parse().expect("valid address"),
             "0.0.0.0:587".parse().expect("valid address"),
             "0.0.0.0:465".parse().expect("valid address"),
@@ -89,11 +93,13 @@ impl ConfigBuilder<WantsServer> {
         self,
         domain: impl Into<String>,
         vsmtp_user: impl Into<String>,
+        vsmtp_group: impl Into<String>,
         thread_count: Option<usize>,
     ) -> ConfigBuilder<WantsLogging> {
         self.with_server(
             domain,
             vsmtp_user,
+            vsmtp_group,
             "0.0.0.0:10025".parse().expect("valid address"),
             "0.0.0.0:10587".parse().expect("valid address"),
             "0.0.0.0:10465".parse().expect("valid address"),

--- a/src/config/config_builder.rs
+++ b/src/config/config_builder.rs
@@ -48,6 +48,7 @@ impl ConfigBuilder<WantsServer> {
     pub fn with_server(
         self,
         domain: impl Into<String>,
+        vsmtp_user: impl Into<String>,
         addr: std::net::SocketAddr,
         addr_submission: std::net::SocketAddr,
         addr_submissions: std::net::SocketAddr,
@@ -62,6 +63,7 @@ impl ConfigBuilder<WantsServer> {
                     addr_submission,
                     addr_submissions,
                     thread_count,
+                    vsmtp_user: vsmtp_user.into(),
                 },
             },
         }
@@ -70,10 +72,12 @@ impl ConfigBuilder<WantsServer> {
     pub fn with_rfc_port(
         self,
         domain: impl Into<String>,
+        vsmtp_user: impl Into<String>,
         thread_count: Option<usize>,
     ) -> ConfigBuilder<WantsLogging> {
         self.with_server(
             domain,
+            vsmtp_user,
             "0.0.0.0:25".parse().expect("valid address"),
             "0.0.0.0:587".parse().expect("valid address"),
             "0.0.0.0:465".parse().expect("valid address"),
@@ -84,10 +88,12 @@ impl ConfigBuilder<WantsServer> {
     pub fn with_debug_port(
         self,
         domain: impl Into<String>,
+        vsmtp_user: impl Into<String>,
         thread_count: Option<usize>,
     ) -> ConfigBuilder<WantsLogging> {
         self.with_server(
             domain,
+            vsmtp_user,
             "0.0.0.0:10025".parse().expect("valid address"),
             "0.0.0.0:10587".parse().expect("valid address"),
             "0.0.0.0:10465".parse().expect("valid address"),

--- a/src/config/default.rs
+++ b/src/config/default.rs
@@ -24,7 +24,8 @@ impl Default for InnerServerConfig {
     fn default() -> Self {
         Self {
             domain: Default::default(),
-            vsmtp_user: Default::default(),
+            vsmtp_user: "vsmtp".to_string(),
+            vsmtp_group: "vsmtp".to_string(),
             addr: "0.0.0.0:25".parse().expect("valid address"),
             addr_submission: "0.0.0.0:587".parse().expect("valid address"),
             addr_submissions: "0.0.0.0:465".parse().expect("valid address"),

--- a/src/config/default.rs
+++ b/src/config/default.rs
@@ -24,6 +24,7 @@ impl Default for InnerServerConfig {
     fn default() -> Self {
         Self {
             domain: Default::default(),
+            vsmtp_user: Default::default(),
             addr: "0.0.0.0:25".parse().expect("valid address"),
             addr_submission: "0.0.0.0:587".parse().expect("valid address"),
             addr_submissions: "0.0.0.0:465".parse().expect("valid address"),

--- a/src/config/server_config.rs
+++ b/src/config/server_config.rs
@@ -23,6 +23,7 @@ use crate::smtp::{code::SMTPReplyCode, state::StateSMTP};
 pub struct InnerServerConfig {
     pub domain: String,
     pub vsmtp_user: String,
+    pub vsmtp_group: String,
     #[serde(default = "InnerServerConfig::default_addr")]
     pub addr: std::net::SocketAddr,
     #[serde(default = "InnerServerConfig::default_addr_submission")]

--- a/src/config/server_config.rs
+++ b/src/config/server_config.rs
@@ -22,6 +22,7 @@ use crate::smtp::{code::SMTPReplyCode, state::StateSMTP};
 #[serde(deny_unknown_fields)]
 pub struct InnerServerConfig {
     pub domain: String,
+    pub vsmtp_user: String,
     #[serde(default = "InnerServerConfig::default_addr")]
     pub addr: std::net::SocketAddr,
     #[serde(default = "InnerServerConfig::default_addr_submission")]

--- a/src/config/template/services.toml
+++ b/src/config/template/services.toml
@@ -1,5 +1,6 @@
 [server]
 domain = "testserver.com"
+vsmtp_user = "vsmtp"
 
 [logs.level]
 default = "warn"

--- a/src/config/template/services.toml
+++ b/src/config/template/services.toml
@@ -1,6 +1,7 @@
 [server]
 domain = "testserver.com"
 vsmtp_user = "vsmtp"
+vsmtp_group = "vsmtp"
 
 [logs.level]
 default = "warn"

--- a/src/config/template/simple.toml
+++ b/src/config/template/simple.toml
@@ -1,5 +1,6 @@
 [server]
 domain = "testserver.com"
+vsmtp_user = "vsmtp"
 
 [logs.level]
 default = "warn"

--- a/src/config/template/simple.toml
+++ b/src/config/template/simple.toml
@@ -1,6 +1,7 @@
 [server]
 domain = "testserver.com"
 vsmtp_user = "vsmtp"
+vsmtp_group = "vsmtp"
 
 [logs.level]
 default = "warn"

--- a/src/config/template/smtps.toml
+++ b/src/config/template/smtps.toml
@@ -1,5 +1,6 @@
 [server]
 domain = "testserver.com"
+vsmtp_user = "vsmtp"
 addr = "0.0.0.0:25"
 addr_submission = "0.0.0.0:587"
 addr_submissions = "0.0.0.0:465"

--- a/src/config/template/smtps.toml
+++ b/src/config/template/smtps.toml
@@ -1,6 +1,8 @@
 [server]
 domain = "testserver.com"
 vsmtp_user = "vsmtp"
+vsmtp_group = "vsmtp"
+
 addr = "0.0.0.0:25"
 addr_submission = "0.0.0.0:587"
 addr_submissions = "0.0.0.0:465"

--- a/src/config/tests/mod.rs
+++ b/src/config/tests/mod.rs
@@ -8,7 +8,7 @@ use super::server_config::{QueueConfig, ServerConfig, Service, TlsSecurityLevel}
 #[test]
 fn init() -> anyhow::Result<()> {
     let _config = ServerConfig::builder()
-        .with_rfc_port("test.server.com", None)
+        .with_rfc_port("test.server.com", "root", None)
         .with_logging(
             "./tmp/log",
             std::collections::HashMap::<String, log::LevelFilter>::default(),
@@ -36,7 +36,7 @@ fn init() -> anyhow::Result<()> {
 #[test]
 fn init_no_smtps() -> anyhow::Result<()> {
     let _config = ServerConfig::builder()
-        .with_rfc_port("test.server.com", None)
+        .with_rfc_port("test.server.com", "root", None)
         .with_logging(
             "./tmp/log",
             std::collections::HashMap::<String, log::LevelFilter>::default(),
@@ -65,7 +65,7 @@ fn from_toml_template_simple() -> anyhow::Result<()> {
     assert_eq!(
         ServerConfig::from_toml(include_str!("../template/simple.toml")).unwrap(),
         ServerConfig::builder()
-            .with_rfc_port("testserver.com", None)
+            .with_rfc_port("testserver.com", "vsmtp", None)
             .with_logging(
                 "/var/log/vsmtp/vsmtp.log",
                 crate::collection! {
@@ -109,6 +109,7 @@ fn from_toml_template_smtps() -> anyhow::Result<()> {
         ServerConfig::builder()
             .with_server(
                 "testserver.com",
+                "vsmtp",
                 "0.0.0.0:25".parse().expect("valid address"),
                 "0.0.0.0:587".parse().expect("valid address"),
                 "0.0.0.0:465".parse().expect("valid address"),
@@ -169,7 +170,7 @@ fn from_toml_template_services() -> anyhow::Result<()> {
     assert_eq!(
         ServerConfig::from_toml(include_str!("../template/services.toml")).unwrap(),
         ServerConfig::builder()
-            .with_rfc_port("testserver.com", None)
+            .with_rfc_port("testserver.com", "vsmtp", None)
             .with_logging(
                 "/var/log/vsmtp/vsmtp.log",
                 crate::collection! {

--- a/src/config/tests/mod.rs
+++ b/src/config/tests/mod.rs
@@ -8,7 +8,7 @@ use super::server_config::{QueueConfig, ServerConfig, Service, TlsSecurityLevel}
 #[test]
 fn init() -> anyhow::Result<()> {
     let _config = ServerConfig::builder()
-        .with_rfc_port("test.server.com", "root", None)
+        .with_rfc_port("test.server.com", "root", "root", None)
         .with_logging(
             "./tmp/log",
             std::collections::HashMap::<String, log::LevelFilter>::default(),
@@ -36,7 +36,7 @@ fn init() -> anyhow::Result<()> {
 #[test]
 fn init_no_smtps() -> anyhow::Result<()> {
     let _config = ServerConfig::builder()
-        .with_rfc_port("test.server.com", "root", None)
+        .with_rfc_port("test.server.com", "root", "root", None)
         .with_logging(
             "./tmp/log",
             std::collections::HashMap::<String, log::LevelFilter>::default(),
@@ -65,7 +65,7 @@ fn from_toml_template_simple() -> anyhow::Result<()> {
     assert_eq!(
         ServerConfig::from_toml(include_str!("../template/simple.toml")).unwrap(),
         ServerConfig::builder()
-            .with_rfc_port("testserver.com", "vsmtp", None)
+            .with_rfc_port("testserver.com", "vsmtp", "vsmtp", None)
             .with_logging(
                 "/var/log/vsmtp/vsmtp.log",
                 crate::collection! {
@@ -109,6 +109,7 @@ fn from_toml_template_smtps() -> anyhow::Result<()> {
         ServerConfig::builder()
             .with_server(
                 "testserver.com",
+                "vsmtp",
                 "vsmtp",
                 "0.0.0.0:25".parse().expect("valid address"),
                 "0.0.0.0:587".parse().expect("valid address"),
@@ -170,7 +171,7 @@ fn from_toml_template_services() -> anyhow::Result<()> {
     assert_eq!(
         ServerConfig::from_toml(include_str!("../template/services.toml")).unwrap(),
         ServerConfig::builder()
-            .with_rfc_port("testserver.com", "vsmtp", None)
+            .with_rfc_port("testserver.com", "vsmtp", "vsmtp", None)
             .with_logging(
                 "/var/log/vsmtp/vsmtp.log",
                 crate::collection! {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@
  **/
 pub mod config;
 pub mod mime;
+pub mod my_libc;
 pub mod processes;
 pub mod queue;
 pub mod receiver;

--- a/src/my_libc.rs
+++ b/src/my_libc.rs
@@ -1,0 +1,38 @@
+pub enum Fork {
+    Parent(libc::pid_t),
+    Child,
+}
+
+#[inline]
+pub fn fork() -> anyhow::Result<Fork> {
+    match unsafe { libc::fork() } {
+        -1 => Err(anyhow::anyhow!(
+            "fork: '{}'",
+            std::io::Error::last_os_error()
+        )),
+        0 => Ok(Fork::Child),
+        child_pid => Ok(Fork::Parent(child_pid)),
+    }
+}
+
+#[inline]
+pub fn setuid(uid: libc::uid_t) -> anyhow::Result<i32> {
+    match unsafe { libc::setuid(uid) } {
+        -1 => Err(anyhow::anyhow!(
+            "setuid: '{}'",
+            std::io::Error::last_os_error()
+        )),
+        otherwise => Ok(otherwise),
+    }
+}
+
+#[inline]
+pub fn setgid(gid: libc::gid_t) -> anyhow::Result<i32> {
+    match unsafe { libc::setgid(gid) } {
+        -1 => Err(anyhow::anyhow!(
+            "setgid: '{}'",
+            std::io::Error::last_os_error()
+        )),
+        otherwise => Ok(otherwise),
+    }
+}

--- a/src/receiver/tests/clair.rs
+++ b/src/receiver/tests/clair.rs
@@ -26,7 +26,7 @@ use crate::{
 
 fn get_regular_config() -> anyhow::Result<ServerConfig> {
     ServerConfig::builder()
-        .with_rfc_port("test.server.com", "foo", None)
+        .with_rfc_port("test.server.com", "foo", "foo", None)
         .without_log()
         .without_smtps()
         .with_default_smtp()
@@ -197,7 +197,7 @@ async fn test_receiver_10() {
         .as_bytes(),
         std::sync::Arc::new(
             ServerConfig::builder()
-                .with_rfc_port("test.server.com", "foo", None)
+                .with_rfc_port("test.server.com", "foo", "foo", None)
                 .without_log()
                 .with_safe_default_smtps(TlsSecurityLevel::Encrypt, "dummy", "dummy", None)
                 .with_default_smtp()

--- a/src/receiver/tests/clair.rs
+++ b/src/receiver/tests/clair.rs
@@ -26,7 +26,7 @@ use crate::{
 
 fn get_regular_config() -> anyhow::Result<ServerConfig> {
     ServerConfig::builder()
-        .with_rfc_port("test.server.com", None)
+        .with_rfc_port("test.server.com", "foo", None)
         .without_log()
         .without_smtps()
         .with_default_smtp()
@@ -197,7 +197,7 @@ async fn test_receiver_10() {
         .as_bytes(),
         std::sync::Arc::new(
             ServerConfig::builder()
-                .with_rfc_port("test.server.com", None)
+                .with_rfc_port("test.server.com", "foo", None)
                 .without_log()
                 .with_safe_default_smtps(TlsSecurityLevel::Encrypt, "dummy", "dummy", None)
                 .with_default_smtp()

--- a/src/receiver/tests/rset.rs
+++ b/src/receiver/tests/rset.rs
@@ -24,7 +24,7 @@ use crate::{
 
 fn get_regular_config() -> ServerConfig {
     ServerConfig::builder()
-        .with_rfc_port("test.server.com", None)
+        .with_rfc_port("test.server.com", "foo", None)
         .without_log()
         .without_smtps()
         .with_default_smtp()

--- a/src/receiver/tests/rset.rs
+++ b/src/receiver/tests/rset.rs
@@ -24,7 +24,7 @@ use crate::{
 
 fn get_regular_config() -> ServerConfig {
     ServerConfig::builder()
-        .with_rfc_port("test.server.com", "foo", None)
+        .with_rfc_port("test.server.com", "foo", "foo", None)
         .without_log()
         .without_smtps()
         .with_default_smtp()

--- a/src/receiver/tests/starttls.rs
+++ b/src/receiver/tests/starttls.rs
@@ -13,7 +13,7 @@ use crate::{
 
 fn get_regular_config() -> anyhow::Result<ServerConfig> {
     ServerConfig::builder()
-        .with_rfc_port("test.server.com", "foo", None)
+        .with_rfc_port("test.server.com", "foo", "foo", None)
         .without_log()
         .without_smtps()
         .with_default_smtp()
@@ -156,7 +156,7 @@ async fn simple() -> anyhow::Result<()> {
         "testserver.com",
         std::sync::Arc::new(
             ServerConfig::builder()
-                .with_rfc_port("testserver.com", "foo", None)
+                .with_rfc_port("testserver.com", "foo", "foo", None)
                 .without_log()
                 .with_safe_default_smtps(
                     TlsSecurityLevel::May,
@@ -291,7 +291,7 @@ async fn test_receiver_8() -> anyhow::Result<()> {
         .as_bytes(),
         std::sync::Arc::new(
             ServerConfig::builder()
-                .with_rfc_port("test.server.com", "foo", None)
+                .with_rfc_port("test.server.com", "foo", "foo", None)
                 .without_log()
                 .with_safe_default_smtps(TlsSecurityLevel::Encrypt, "dummy", "dummy", None)
                 .with_default_smtp()

--- a/src/receiver/tests/starttls.rs
+++ b/src/receiver/tests/starttls.rs
@@ -13,7 +13,7 @@ use crate::{
 
 fn get_regular_config() -> anyhow::Result<ServerConfig> {
     ServerConfig::builder()
-        .with_rfc_port("test.server.com", None)
+        .with_rfc_port("test.server.com", "foo", None)
         .without_log()
         .without_smtps()
         .with_default_smtp()
@@ -156,7 +156,7 @@ async fn simple() -> anyhow::Result<()> {
         "testserver.com",
         std::sync::Arc::new(
             ServerConfig::builder()
-                .with_rfc_port("testserver.com", None)
+                .with_rfc_port("testserver.com", "foo", None)
                 .without_log()
                 .with_safe_default_smtps(
                     TlsSecurityLevel::May,
@@ -291,7 +291,7 @@ async fn test_receiver_8() -> anyhow::Result<()> {
         .as_bytes(),
         std::sync::Arc::new(
             ServerConfig::builder()
-                .with_rfc_port("test.server.com", None)
+                .with_rfc_port("test.server.com", "foo", None)
                 .without_log()
                 .with_safe_default_smtps(TlsSecurityLevel::Encrypt, "dummy", "dummy", None)
                 .with_default_smtp()

--- a/src/receiver/tests/tls_tunneled.rs
+++ b/src/receiver/tests/tls_tunneled.rs
@@ -118,7 +118,7 @@ async fn simple() -> anyhow::Result<()> {
         "testserver.com",
         std::sync::Arc::new(
             ServerConfig::builder()
-                .with_rfc_port("testserver.com", "foo", None)
+                .with_rfc_port("testserver.com", "foo", "foo", None)
                 .without_log()
                 .with_safe_default_smtps(
                     TlsSecurityLevel::Encrypt,
@@ -163,7 +163,7 @@ async fn sni() -> anyhow::Result<()> {
         "second.testserver.com",
         std::sync::Arc::new(
             ServerConfig::builder()
-                .with_rfc_port("testserver.com", "foo", None)
+                .with_rfc_port("testserver.com", "foo", "foo", None)
                 .without_log()
                 .with_safe_default_smtps(
                     TlsSecurityLevel::Encrypt,

--- a/src/receiver/tests/tls_tunneled.rs
+++ b/src/receiver/tests/tls_tunneled.rs
@@ -118,7 +118,7 @@ async fn simple() -> anyhow::Result<()> {
         "testserver.com",
         std::sync::Arc::new(
             ServerConfig::builder()
-                .with_rfc_port("testserver.com", None)
+                .with_rfc_port("testserver.com", "foo", None)
                 .without_log()
                 .with_safe_default_smtps(
                     TlsSecurityLevel::Encrypt,
@@ -163,7 +163,7 @@ async fn sni() -> anyhow::Result<()> {
         "second.testserver.com",
         std::sync::Arc::new(
             ServerConfig::builder()
-                .with_rfc_port("testserver.com", None)
+                .with_rfc_port("testserver.com", "foo", None)
                 .without_log()
                 .with_safe_default_smtps(
                     TlsSecurityLevel::Encrypt,

--- a/src/receiver/tests/utf8.rs
+++ b/src/receiver/tests/utf8.rs
@@ -74,7 +74,7 @@ macro_rules! test_lang {
             .as_bytes(),
             std::sync::Arc::new(
                 ServerConfig::builder()
-                    .with_rfc_port("test.server.com", None)
+                    .with_rfc_port("test.server.com", "foo", None)
                     .without_log()
                     .without_smtps()
                     .with_default_smtp()

--- a/src/receiver/tests/utf8.rs
+++ b/src/receiver/tests/utf8.rs
@@ -74,7 +74,7 @@ macro_rules! test_lang {
             .as_bytes(),
             std::sync::Arc::new(
                 ServerConfig::builder()
-                    .with_rfc_port("test.server.com", "foo", None)
+                    .with_rfc_port("test.server.com", "foo", "foo", None)
                     .without_log()
                     .without_smtps()
                     .with_default_smtp()

--- a/src/rules/tests/mod.rs
+++ b/src/rules/tests/mod.rs
@@ -27,7 +27,7 @@ pub mod helpers {
 
     pub(super) fn get_default_state() -> RuleState<'static> {
         let config = ServerConfig::builder()
-            .with_rfc_port("test.server.com", None)
+            .with_rfc_port("test.server.com", "foo", None)
             .without_log()
             .without_smtps()
             .with_default_smtp()

--- a/src/rules/tests/mod.rs
+++ b/src/rules/tests/mod.rs
@@ -27,7 +27,7 @@ pub mod helpers {
 
     pub(super) fn get_default_state() -> RuleState<'static> {
         let config = ServerConfig::builder()
-            .with_rfc_port("test.server.com", "foo", None)
+            .with_rfc_port("test.server.com", "foo", "foo", None)
             .without_log()
             .without_smtps()
             .with_default_smtp()

--- a/src/server.rs
+++ b/src/server.rs
@@ -39,7 +39,14 @@ pub struct ServerVSMTP {
 }
 
 impl ServerVSMTP {
-    pub async fn new(config: std::sync::Arc<ServerConfig>) -> anyhow::Result<Self> {
+    pub fn new(
+        config: std::sync::Arc<ServerConfig>,
+        sockets: (
+            std::net::TcpListener,
+            std::net::TcpListener,
+            std::net::TcpListener,
+        ),
+    ) -> anyhow::Result<Self> {
         if !config.delivery.spool_dir.exists() {
             std::fs::DirBuilder::new()
                 .recursive(true)
@@ -52,11 +59,9 @@ impl ServerVSMTP {
 
         Ok(Self {
             resolvers,
-            listener: tokio::net::TcpListener::bind(&config.server.addr).await?,
-            listener_submission: tokio::net::TcpListener::bind(&config.server.addr_submission)
-                .await?,
-            listener_submissions: tokio::net::TcpListener::bind(&config.server.addr_submissions)
-                .await?,
+            listener: tokio::net::TcpListener::from_std(sockets.0)?,
+            listener_submission: tokio::net::TcpListener::from_std(sockets.1)?,
+            listener_submissions: tokio::net::TcpListener::from_std(sockets.2)?,
             tls_config: if let Some(smtps) = &config.smtps {
                 Some(std::sync::Arc::new(get_rustls_config(smtps)?))
             } else {
@@ -257,23 +262,35 @@ mod tests {
             "0.0.0.0:10466".parse().expect("valid address"),
         );
 
-        let config = ServerConfig::builder()
-            .with_server(
-                "test.server.com",
-                addr,
-                addr_submission,
-                addr_submissions,
-                num_cpus::get(),
-            )
-            .without_log()
-            .without_smtps()
-            .with_default_smtp()
-            .with_delivery("./tmp/trash", crate::collection! {})
-            .with_rules("./tmp/no_rules", vec![])
-            .with_default_reply_codes()
-            .build()?;
+        let config = std::sync::Arc::new(
+            ServerConfig::builder()
+                .with_server(
+                    "test.server.com",
+                    "foo",
+                    addr,
+                    addr_submission,
+                    addr_submissions,
+                    num_cpus::get(),
+                )
+                .without_log()
+                .without_smtps()
+                .with_default_smtp()
+                .with_delivery("./tmp/trash", crate::collection! {})
+                .with_rules("./tmp/no_rules", vec![])
+                .with_default_reply_codes()
+                .build()
+                .unwrap(),
+        );
 
-        let s = ServerVSMTP::new(std::sync::Arc::new(config)).await.unwrap();
+        let s = ServerVSMTP::new(
+            config.clone(),
+            (
+                std::net::TcpListener::bind(config.server.addr)?,
+                std::net::TcpListener::bind(config.server.addr_submission)?,
+                std::net::TcpListener::bind(config.server.addr_submissions)?,
+            ),
+        )
+        .unwrap();
         assert_eq!(s.addr(), vec![addr, addr_submission, addr_submissions]);
         Ok(())
     }
@@ -287,28 +304,40 @@ mod tests {
             "0.0.0.0:10466".parse().expect("valid address"),
         );
 
-        let config = ServerConfig::builder()
-            .with_server(
-                "test.server.com",
-                addr,
-                addr_submission,
-                addr_submissions,
-                num_cpus::get(),
-            )
-            .without_log()
-            .with_safe_default_smtps(
-                TlsSecurityLevel::May,
-                "./src/receiver/tests/certs/certificate.crt",
-                "./src/receiver/tests/certs/privateKey.key",
-                None,
-            )
-            .with_default_smtp()
-            .with_delivery("./tmp/trash", crate::collection! {})
-            .with_rules("./tmp/no_rules", vec![])
-            .with_default_reply_codes()
-            .build()?;
+        let config = std::sync::Arc::new(
+            ServerConfig::builder()
+                .with_server(
+                    "test.server.com",
+                    "foo",
+                    addr,
+                    addr_submission,
+                    addr_submissions,
+                    num_cpus::get(),
+                )
+                .without_log()
+                .with_safe_default_smtps(
+                    TlsSecurityLevel::May,
+                    "./src/receiver/tests/certs/certificate.crt",
+                    "./src/receiver/tests/certs/privateKey.key",
+                    None,
+                )
+                .with_default_smtp()
+                .with_delivery("./tmp/trash", crate::collection! {})
+                .with_rules("./tmp/no_rules", vec![])
+                .with_default_reply_codes()
+                .build()
+                .unwrap(),
+        );
 
-        let s = ServerVSMTP::new(std::sync::Arc::new(config)).await.unwrap();
+        let s = ServerVSMTP::new(
+            config.clone(),
+            (
+                std::net::TcpListener::bind(config.server.addr)?,
+                std::net::TcpListener::bind(config.server.addr_submission)?,
+                std::net::TcpListener::bind(config.server.addr_submissions)?,
+            ),
+        )
+        .unwrap();
         assert_eq!(s.addr(), vec![addr, addr_submission, addr_submissions]);
         Ok(())
     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -267,6 +267,7 @@ mod tests {
                 .with_server(
                     "test.server.com",
                     "foo",
+                    "foo",
                     addr,
                     addr_submission,
                     addr_submissions,
@@ -308,6 +309,7 @@ mod tests {
             ServerConfig::builder()
                 .with_server(
                     "test.server.com",
+                    "foo",
                     "foo",
                     addr,
                     addr_submission,

--- a/tests/stress.rs
+++ b/tests/stress.rs
@@ -96,6 +96,7 @@ async fn stress() {
     let config = ServerConfig::builder()
         .with_server(
             "stress.server.com",
+            "foo",
             "0.0.0.0:10027".parse().expect("valid address"),
             "0.0.0.0:10589".parse().expect("valid address"),
             "0.0.0.0:10467".parse().expect("valid address"),
@@ -115,8 +116,13 @@ async fn stress() {
 
     log4rs::init_config(get_logger_config(&config).unwrap()).unwrap();
 
-    let mut server = ServerVSMTP::new(std::sync::Arc::new(config))
-        .await
+    let sockets = (
+        std::net::TcpListener::bind(config.server.addr).unwrap(),
+        std::net::TcpListener::bind(config.server.addr_submission).unwrap(),
+        std::net::TcpListener::bind(config.server.addr_submissions).unwrap(),
+    );
+
+    let mut server = ServerVSMTP::new(std::sync::Arc::new(config), sockets)
         .expect("failed to initialize server");
 
     let tracer = opentelemetry_jaeger::new_pipeline()

--- a/tests/stress.rs
+++ b/tests/stress.rs
@@ -97,6 +97,7 @@ async fn stress() {
         .with_server(
             "stress.server.com",
             "foo",
+            "foo",
             "0.0.0.0:10027".parse().expect("valid address"),
             "0.0.0.0:10589".parse().expect("valid address"),
             "0.0.0.0:10467".parse().expect("valid address"),


### PR DESCRIPTION
* add a mandatory vsmtp_user and vsmtp_group in config
* fork the process after initialize config
* sockets are binded before forking
* change uid/gid in child process (server)
* using "foo" vsmtp_user / vsmtp_group on test as field is not used (only in main.rs)