### PR TITLE
Default config for vSMTP args

### DIFF
--- a/vsmtp-common/src/state.rs
+++ b/vsmtp-common/src/state.rs
@@ -68,19 +68,8 @@ impl From<StateSMTP> for String {
     }
 }
 
-/// Error return type of StateSMTP::from_str
-#[allow(clippy::module_name_repetitions)]
-#[derive(Debug, PartialEq, Eq)]
-pub struct StateSMTPFromStrError;
-
-impl std::fmt::Display for StateSMTPFromStrError {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        f.write_str("StateSMTPFromStrError")
-    }
-}
-
 impl std::str::FromStr for StateSMTP {
-    type Err = StateSMTPFromStrError;
+    type Err = anyhow::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
@@ -91,13 +80,13 @@ impl std::str::FromStr for StateSMTP {
             "RcptTo" => Ok(Self::RcptTo),
             "Data" => Ok(Self::Data),
             "Stop" => Ok(Self::Stop),
-            _ => Err(StateSMTPFromStrError),
+            _ => Err(anyhow::anyhow!("not a valid SMTP state: '{}'", s)),
         }
     }
 }
 
 impl TryFrom<String> for StateSMTP {
-    type Error = StateSMTPFromStrError;
+    type Error = anyhow::Error;
 
     fn try_from(value: String) -> Result<Self, Self::Error> {
         <Self as std::str::FromStr>::from_str(&value)
@@ -113,40 +102,17 @@ mod tests {
     #[test]
     fn error() {
         assert_eq!(
-            format!("{}", StateSMTP::from_str("root").unwrap_err()),
-            "StateSMTPFromStrError"
+            format!("{}", StateSMTP::from_str("foobar").unwrap_err()),
+            "not a valid SMTP state: 'foobar'"
         );
-    }
-
-    #[test]
-    fn to_str() {
-        assert_eq!(format!("{}", StateSMTP::Connect), "Connect");
-        assert_eq!(format!("{}", StateSMTP::Helo), "Helo");
-        assert_eq!(format!("{}", StateSMTP::MailFrom), "MailFrom");
-        assert_eq!(format!("{}", StateSMTP::RcptTo), "RcptTo");
-        assert_eq!(format!("{}", StateSMTP::Data), "Data");
-        assert_eq!(format!("{}", StateSMTP::NegotiationTLS), "NegotiationTLS");
-        assert_eq!(format!("{}", StateSMTP::Stop), "Stop");
-    }
-
-    #[test]
-    fn from_str() {
-        assert_eq!(StateSMTP::from_str("Connect"), Ok(StateSMTP::Connect));
-        assert_eq!(StateSMTP::from_str("Helo"), Ok(StateSMTP::Helo));
-        assert_eq!(StateSMTP::from_str("MailFrom"), Ok(StateSMTP::MailFrom));
-        assert_eq!(StateSMTP::from_str("RcptTo"), Ok(StateSMTP::RcptTo));
-        assert_eq!(StateSMTP::from_str("Data"), Ok(StateSMTP::Data));
-        assert_eq!(
-            StateSMTP::from_str("NegotiationTLS"),
-            Ok(StateSMTP::NegotiationTLS)
-        );
-        assert_eq!(StateSMTP::from_str("Stop"), Ok(StateSMTP::Stop));
     }
 
     #[test]
     fn same() {
         for s in <StateSMTP as enum_iterator::IntoEnumIterator>::into_enum_iter() {
+            println!("{:?}", s);
             assert_eq!(StateSMTP::from_str(&format!("{}", s)).unwrap(), s);
+            assert_eq!(String::try_from(s).unwrap(), format!("{}", s));
         }
     }
 }

--- a/vsmtp-config/src/parser/semver.rs
+++ b/vsmtp-config/src/parser/semver.rs
@@ -12,3 +12,23 @@ where
     semver::VersionReq::parse(&<String as serde::Deserialize>::deserialize(deserializer)?)
         .map_err(serde::de::Error::custom)
 }
+
+#[cfg(test)]
+mod tests {
+
+    #[derive(serde::Serialize, serde::Deserialize)]
+    struct S {
+        #[serde(
+            serialize_with = "crate::parser::semver::serialize",
+            deserialize_with = "crate::parser::semver::deserialize"
+        )]
+        v: semver::VersionReq,
+    }
+
+    #[test]
+    fn serialize_deserialize() {
+        let str = r#"{"v":"^1.0.0"}"#;
+        let s: S = serde_json::from_str(str).unwrap();
+        assert_eq!(str, serde_json::to_string(&s).unwrap());
+    }
+}

--- a/vsmtp-config/src/parser/socket_addr.rs
+++ b/vsmtp-config/src/parser/socket_addr.rs
@@ -49,93 +49,90 @@ mod test {
     #[test]
     fn socket_addr_ipv4() {
         assert_eq!(
-            S {
-                v: vec![std::net::SocketAddr::new(
-                    std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST),
-                    25
-                )]
-            }
-            .v,
-            toml::from_str::<S>(r#"v = ["127.0.0.1:25"]"#).unwrap().v
+            vec![std::net::SocketAddr::new(
+                std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST),
+                25
+            )],
+            serde_json::from_str::<S>(r#"{"v": ["127.0.0.1:25"]}"#)
+                .unwrap()
+                .v
         );
 
         assert_eq!(
-            S {
-                v: vec![std::net::SocketAddr::new(
-                    std::net::IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED),
-                    465
-                )]
-            }
-            .v,
-            toml::from_str::<S>(r#"v = ["0.0.0.0:465"]"#).unwrap().v
+            vec![std::net::SocketAddr::new(
+                std::net::IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED),
+                465
+            )],
+            serde_json::from_str::<S>(r#"{"v": ["0.0.0.0:465"]}"#)
+                .unwrap()
+                .v
         );
     }
 
     #[test]
     fn socket_addr_ipv6() {
         assert_eq!(
-            S {
-                v: vec![std::net::SocketAddr::new(
-                    std::net::IpAddr::V6(std::net::Ipv6Addr::LOCALHOST),
-                    25
-                )]
-            }
-            .v,
-            toml::from_str::<S>(r#"v = ["[::1]:25"]"#).unwrap().v
+            vec![std::net::SocketAddr::new(
+                std::net::IpAddr::V6(std::net::Ipv6Addr::LOCALHOST),
+                25
+            )],
+            serde_json::from_str::<S>(r#"{"v": ["[::1]:25"]}"#)
+                .unwrap()
+                .v
         );
 
         assert_eq!(
-            S {
-                v: vec![std::net::SocketAddr::new(
-                    std::net::IpAddr::V6(std::net::Ipv6Addr::UNSPECIFIED),
-                    465
-                )]
-            }
-            .v,
-            toml::from_str::<S>(r#"v = ["[::]:465"]"#).unwrap().v
+            vec![std::net::SocketAddr::new(
+                std::net::IpAddr::V6(std::net::Ipv6Addr::UNSPECIFIED),
+                465
+            )],
+            serde_json::from_str::<S>(r#"{"v": ["[::]:465"]}"#)
+                .unwrap()
+                .v
         );
     }
 
     #[test]
     fn socket_addr_ipv6_with_scope_id() {
-        assert_eq!(
-            format!(
-                "{:?}",
-                toml::from_str::<S>(r#"v = ["[::1%foobar]:25"]"#).unwrap_err()
-            ),
-            r#"Error { inner: ErrorInner { kind: Custom, line: Some(0), col: 0, at: Some(0), message: "if_nametoindex: 'No such device (os error 19)'", key: ["v"] } }"#
-        );
-
         let interface1 = if_indextoname(1).unwrap();
 
         assert_eq!(
-            S {
-                v: vec![std::net::SocketAddr::V6(std::net::SocketAddrV6::new(
-                    std::net::Ipv6Addr::LOCALHOST,
-                    25,
-                    0,
-                    if_nametoindex(&interface1).unwrap(),
-                ))]
-            }
-            .v,
-            toml::from_str::<S>(&format!(r#"v = ["[::1%{interface1}]:25"]"#))
+            vec![std::net::SocketAddr::V6(std::net::SocketAddrV6::new(
+                std::net::Ipv6Addr::LOCALHOST,
+                25,
+                0,
+                if_nametoindex(&interface1).unwrap(),
+            ))],
+            serde_json::from_str::<S>(&format!(r#"{{"v": ["[::1%{interface1}]:25"]}}"#))
                 .unwrap()
                 .v
         );
 
         assert_eq!(
-            S {
-                v: vec![std::net::SocketAddr::V6(std::net::SocketAddrV6::new(
-                    std::net::Ipv6Addr::UNSPECIFIED,
-                    465,
-                    0,
-                    if_nametoindex(&interface1).unwrap(),
-                ))]
-            }
-            .v,
-            toml::from_str::<S>(&format!(r#"v = ["[::%{interface1}]:465"]"#))
+            vec![std::net::SocketAddr::V6(std::net::SocketAddrV6::new(
+                std::net::Ipv6Addr::UNSPECIFIED,
+                465,
+                0,
+                if_nametoindex(&interface1).unwrap(),
+            ))],
+            serde_json::from_str::<S>(&format!(r#"{{"v": ["[::%{interface1}]:465"]}}"#))
                 .unwrap()
                 .v
         );
+    }
+
+    #[test]
+    fn socket_addr_ipv6_with_scope_id_error() {
+        assert!(serde_json::from_str::<S>(r#"{"v": ["[::1%foobar]"]}"#)
+            .unwrap_err()
+            .is_data());
+
+        assert!(serde_json::from_str::<S>(r#"{"v": ["::1%foobar:25"]}"#)
+            .unwrap_err()
+            .is_data());
+
+        assert!(serde_json::from_str::<S>(r#"{"v": ["[::1!scope_id]:25"]}"#)
+            .unwrap_err()
+            .is_data());
     }
 }

--- a/vsmtp/src/args.rs
+++ b/vsmtp/src/args.rs
@@ -4,7 +4,7 @@
 pub struct Args {
     /// Path of the vSMTP configuration file (toml format)
     #[clap(short, long)]
-    pub config: String,
+    pub config: Option<String>,
 
     /// Commands
     #[clap(subcommand)]
@@ -31,12 +31,12 @@ mod tests {
 
     #[test]
     fn parse_arg() {
-        assert!(<Args as clap::StructOpt>::try_parse_from(&[""]).is_err());
+        assert!(<Args as clap::StructOpt>::try_parse_from(&[""]).is_ok());
 
         assert_eq!(
             Args {
                 command: None,
-                config: "path".to_string(),
+                config: Some("path".to_string()),
                 no_daemon: false
             },
             <Args as clap::StructOpt>::try_parse_from(&["", "-c", "path"]).unwrap()
@@ -45,7 +45,7 @@ mod tests {
         assert_eq!(
             Args {
                 command: Some(Commands::ConfigShow),
-                config: "path".to_string(),
+                config: Some("path".to_string()),
                 no_daemon: false
             },
             <Args as clap::StructOpt>::try_parse_from(&["", "-c", "path", "config-show"]).unwrap()
@@ -54,7 +54,7 @@ mod tests {
         assert_eq!(
             Args {
                 command: Some(Commands::ConfigDiff),
-                config: "path".to_string(),
+                config: Some("path".to_string()),
                 no_daemon: false
             },
             <Args as clap::StructOpt>::try_parse_from(&["", "-c", "path", "config-diff"]).unwrap()
@@ -63,7 +63,7 @@ mod tests {
         assert_eq!(
             Args {
                 command: None,
-                config: "path".to_string(),
+                config: Some("path".to_string()),
                 no_daemon: true
             },
             <Args as clap::StructOpt>::try_parse_from(&["", "-c", "path", "--no-daemon"]).unwrap()

--- a/vsmtp/src/main.rs
+++ b/vsmtp/src/main.rs
@@ -31,10 +31,13 @@ fn socket_bind_anyhow<A: std::net::ToSocketAddrs + std::fmt::Debug>(
 fn main() -> anyhow::Result<()> {
     let args = <Args as clap::StructOpt>::parse();
 
-    let config = std::fs::read_to_string(&args.config)
-        .with_context(|| format!("Cannot read file '{}'", args.config))
-        .and_then(|data| Config::from_toml(&data).with_context(|| "File contains format error"))
-        .with_context(|| "Cannot parse the configuration")?;
+    let config = match args.config {
+        Some(config) => std::fs::read_to_string(&config)
+            .with_context(|| format!("Cannot read file '{}'", config))
+            .and_then(|data| Config::from_toml(&data).with_context(|| "File contains format error"))
+            .with_context(|| "Cannot parse the configuration")?,
+        None => Config::default(),
+    };
 
     if let Some(command) = args.command {
         match command {


### PR DESCRIPTION
Change the vSMTP args take and optional `--config` (and use default config if missing)

Now then `vsmtp config-show` will print the default config.

Other minor tweaks in tests for coverage