### PR TITLE
CICD test fix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,7 +50,7 @@ jobs:
           key: "${{ runner.os }}-cargo-bin-${{ hashFiles('**/Cargo.lock') }}"
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: nightly-2022-03-22
           override: true
       - uses: actions-rs/cargo@v1
         with:


### PR DESCRIPTION
Set rustc toolchain version temporarily to `nightly-2022-03-22` while the rust team is working on the bug [here](https://github.com/rust-lang/rust/issues/95267). 