### PR TITLE
feat: parse cipher_list & tweaks test for cov

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2086,10 +2086,8 @@ dependencies = [
 name = "vsmtp-delivery"
 version = "0.9.3"
 dependencies = [
- "anyhow",
  "async-trait",
  "lettre",
- "log",
  "time 0.3.9",
  "tokio",
  "trust-dns-resolver",
@@ -2110,7 +2108,6 @@ dependencies = [
 name = "vsmtp-rule-engine"
 version = "0.9.7"
 dependencies = [
- "addr",
  "ipnet",
  "iprange",
  "lettre",

--- a/vsmtp-common/Cargo.toml
+++ b/vsmtp-common/Cargo.toml
@@ -15,7 +15,7 @@ publish = false
 [dependencies]
 anyhow = "1.0.56"
 
-log = "0.4.14"
+log = "0.4.16"
 
 libc = "0.2.109"
 

--- a/vsmtp-common/src/address.rs
+++ b/vsmtp-common/src/address.rs
@@ -62,13 +62,6 @@ impl std::fmt::Display for Address {
     }
 }
 
-#[allow(clippy::from_over_into)]
-impl Into<crate::rcpt::Rcpt> for Address {
-    fn into(self) -> crate::rcpt::Rcpt {
-        crate::rcpt::Rcpt::new(self)
-    }
-}
-
 impl Address {
     /// get the full email address.
     #[must_use]

--- a/vsmtp-common/src/lib.rs
+++ b/vsmtp-common/src/lib.rs
@@ -79,12 +79,12 @@ mod tests {
 
 ///
 pub mod re {
+    pub use addr;
     pub use anyhow;
     pub use libc;
     pub use log;
     pub use rsasl;
     pub use strum;
-    pub use addr;
 }
 
 #[doc(hidden)]

--- a/vsmtp-common/src/lib.rs
+++ b/vsmtp-common/src/lib.rs
@@ -84,6 +84,7 @@ pub mod re {
     pub use log;
     pub use rsasl;
     pub use strum;
+    pub use addr;
 }
 
 #[doc(hidden)]

--- a/vsmtp-common/src/rcpt.rs
+++ b/vsmtp-common/src/rcpt.rs
@@ -53,6 +53,12 @@ impl Rcpt {
     }
 }
 
+impl From<Address> for Rcpt {
+    fn from(this: Address) -> Self {
+        Self::new(this)
+    }
+}
+
 impl std::fmt::Display for Rcpt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.address)
@@ -67,20 +73,17 @@ impl PartialEq for Rcpt {
 
 /// filter recipients by their transfer method.
 #[must_use]
-pub fn filter_by_transfer_method(
-    rcpt: &[Rcpt],
-) -> std::collections::HashMap<crate::transfer::Transfer, Vec<crate::rcpt::Rcpt>> {
-    rcpt.iter()
-        .fold(std::collections::HashMap::new(), |mut acc, rcpt| {
-            let rcpt = rcpt.clone();
-            if let Some(group) = acc.get_mut(&rcpt.transfer_method) {
-                group.push(rcpt);
-            } else {
-                acc.insert(rcpt.transfer_method.clone(), vec![rcpt]);
-            }
-
-            acc
-        })
+pub fn filter_by_transfer_method(rcpt: &[Rcpt]) -> std::collections::HashMap<Transfer, Vec<Rcpt>> {
+    let mut output: std::collections::HashMap<Transfer, Vec<Rcpt>> =
+        std::collections::HashMap::new();
+    for i in rcpt.iter().cloned() {
+        if let Some(group) = output.get_mut(&i.transfer_method) {
+            group.push(i);
+        } else {
+            output.insert(i.transfer_method.clone(), vec![i]);
+        }
+    }
+    output
 }
 
 #[cfg(test)]

--- a/vsmtp-common/src/state.rs
+++ b/vsmtp-common/src/state.rs
@@ -1,5 +1,3 @@
-use crate::mechanism::Mechanism;
-
 /**
  * vSMTP mail transfer agent
  * Copyright (C) 2022 viridIT SAS
@@ -16,6 +14,7 @@ use crate::mechanism::Mechanism;
  * this program. If not, see https://www.gnu.org/licenses/.
  *
 **/
+use crate::mechanism::Mechanism;
 
 /// State of the pipeline SMTP
 #[derive(

--- a/vsmtp-common/src/transfer.rs
+++ b/vsmtp-common/src/transfer.rs
@@ -89,17 +89,66 @@ impl std::fmt::Display for Transfer {
     }
 }
 
-impl TryFrom<&str> for Transfer {
-    type Error = anyhow::Error;
+impl std::str::FromStr for Transfer {
+    type Err = anyhow::Error;
 
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
-        match value {
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
             "forward" => Ok(Self::Forward(String::default())),
             "deliver" => Ok(Self::Deliver),
             "mbox" => Ok(Self::Mbox),
             "maildir" => Ok(Self::Maildir),
             "none" => Ok(Self::None),
-            _ => anyhow::bail!("transfer method '{}' does not exist.", value),
+            _ => anyhow::bail!("transfer method '{}' does not exist.", s),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::{EmailTransferStatus, Transfer};
+
+    mod status {
+        use super::EmailTransferStatus;
+
+        #[test]
+        fn display() {
+            for i in [
+                EmailTransferStatus::Waiting,
+                EmailTransferStatus::Sent,
+                EmailTransferStatus::HeldBack(usize::default()),
+                EmailTransferStatus::Failed(String::default()),
+            ] {
+                println!("{}", i);
+            }
+        }
+    }
+
+    mod transfer {
+        use super::Transfer;
+        use std::str::FromStr;
+
+        #[test]
+        fn error() {
+            assert_eq!(
+                format!("{}", Transfer::from_str("foobar").unwrap_err()),
+                "transfer method 'foobar' does not exist."
+            );
+        }
+
+        #[test]
+        fn same() {
+            for s in [
+                Transfer::None,
+                Transfer::Deliver,
+                Transfer::Maildir,
+                Transfer::Mbox,
+                Transfer::Forward(String::default()),
+            ] {
+                println!("{:?}", s);
+                assert_eq!(Transfer::from_str(&format!("{}", s)).unwrap(), s);
+            }
         }
     }
 }

--- a/vsmtp-config/src/builder/with.rs
+++ b/vsmtp-config/src/builder/with.rs
@@ -328,6 +328,7 @@ impl Builder<WantsServerTLSConfig> {
                     certificate: tls_certificate::from_string(certificate)?,
                     private_key: tls_private_key::from_string(private_key)?,
                     sni: vec![],
+                    cipher_suite: ConfigServerTls::default_cipher_suite(),
                 }),
             },
         })

--- a/vsmtp-config/src/config.rs
+++ b/vsmtp-config/src/config.rs
@@ -205,6 +205,12 @@ pub struct ConfigServerTls {
     )]
     pub protocol_version: Vec<rustls::ProtocolVersion>,
     #[serde(
+        serialize_with = "crate::parser::tls_cipher_suite::serialize",
+        deserialize_with = "crate::parser::tls_cipher_suite::deserialize",
+        default = "ConfigServerTls::default_cipher_suite"
+    )]
+    pub cipher_suite: Vec<rustls::CipherSuite>,
+    #[serde(
         serialize_with = "crate::parser::tls_certificate::serialize",
         deserialize_with = "crate::parser::tls_certificate::deserialize"
     )]

--- a/vsmtp-config/src/default.rs
+++ b/vsmtp-config/src/default.rs
@@ -1,12 +1,5 @@
 #![allow(clippy::module_name_repetitions)]
 
-use vsmtp_common::{
-    auth::Mechanism,
-    code::SMTPReplyCode,
-    collection,
-    re::{log, strum},
-};
-
 use crate::{
     config::{
         ConfigApp, ConfigAppLogs, ConfigAppVSL, ConfigQueueDelivery, ConfigQueueWorking,
@@ -14,12 +7,18 @@ use crate::{
         ConfigServerQueues, ConfigServerSMTP, ConfigServerSMTPAuth, ConfigServerSMTPError,
         ConfigServerSMTPTimeoutClient, ConfigServerSystem, ConfigServerSystemThreadPool,
     },
-    Builder, Config, ConfigServerTls, Service,
+    Config, ConfigServerTls, Service,
+};
+use vsmtp_common::{
+    auth::Mechanism,
+    code::SMTPReplyCode,
+    collection,
+    re::{log, strum},
 };
 
 impl Default for Config {
     fn default() -> Self {
-        Builder::ensure(Self {
+        Self::ensure(Self {
             version_requirement: semver::VersionReq::parse("<1.0.0").unwrap(),
             server: ConfigServer::default(),
             app: ConfigApp::default(),
@@ -215,7 +214,9 @@ impl ConfigServerSMTPAuth {
         false
     }
 
-    pub(crate) fn default_mechanisms() -> Vec<Mechanism> {
+    /// Return all the supported SASL mechanisms
+    #[must_use]
+    pub fn default_mechanisms() -> Vec<Mechanism> {
         <Mechanism as strum::IntoEnumIterator>::iter().collect::<Vec<_>>()
     }
 

--- a/vsmtp-config/src/default.rs
+++ b/vsmtp-config/src/default.rs
@@ -14,7 +14,7 @@ use crate::{
         ConfigServerQueues, ConfigServerSMTP, ConfigServerSMTPAuth, ConfigServerSMTPError,
         ConfigServerSMTPTimeoutClient, ConfigServerSystem, ConfigServerSystemThreadPool,
     },
-    Builder, Config, Service,
+    Builder, Config, ConfigServerTls, Service,
 };
 
 impl Default for Config {
@@ -145,6 +145,24 @@ impl ConfigServerLogs {
         collection! {
             "default".to_string() => log::LevelFilter::Warn
         }
+    }
+}
+
+impl ConfigServerTls {
+    pub(crate) fn default_cipher_suite() -> Vec<rustls::CipherSuite> {
+        vec![
+            // TLS1.3 suites
+            rustls::CipherSuite::TLS13_AES_256_GCM_SHA384,
+            rustls::CipherSuite::TLS13_AES_128_GCM_SHA256,
+            rustls::CipherSuite::TLS13_CHACHA20_POLY1305_SHA256,
+            // TLS1.2 suites
+            rustls::CipherSuite::TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+            rustls::CipherSuite::TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+            rustls::CipherSuite::TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
+            rustls::CipherSuite::TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+            rustls::CipherSuite::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+            rustls::CipherSuite::TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+        ]
     }
 }
 

--- a/vsmtp-config/src/lib.rs
+++ b/vsmtp-config/src/lib.rs
@@ -88,8 +88,6 @@ pub mod re {
 use builder::{Builder, WantsVersion};
 use vsmtp_common::re::anyhow;
 
-use crate::builder::WantsValidate;
-
 impl Config {
     ///
     #[must_use]
@@ -136,7 +134,7 @@ impl Config {
         }
 
         toml::from_str::<Self>(input)
-            .map(Builder::<WantsValidate>::ensure)
+            .map(Self::ensure)
             .map_err(anyhow::Error::new)?
     }
 }

--- a/vsmtp-config/src/lib.rs
+++ b/vsmtp-config/src/lib.rs
@@ -48,6 +48,7 @@ mod parser {
     pub mod syst_group;
     pub mod syst_user;
     pub mod tls_certificate;
+    pub mod tls_cipher_suite;
     pub mod tls_private_key;
     pub mod tls_protocol_version;
 }

--- a/vsmtp-config/src/parser/syst_group.rs
+++ b/vsmtp-config/src/parser/syst_group.rs
@@ -2,7 +2,7 @@ pub fn serialize<S: serde::Serializer>(
     value: &users::Group,
     serializer: S,
 ) -> Result<S::Ok, S::Error> {
-    serde::Serialize::serialize(&value.name(), serializer)
+    serde::Serialize::serialize(&value.name().to_str().unwrap(), serializer)
 }
 
 pub fn deserialize<'de, D>(deserializer: D) -> Result<users::Group, D::Error>
@@ -12,4 +12,35 @@ where
     let group_name = &<String as serde::Deserialize>::deserialize(deserializer)?;
     users::get_group_by_name(group_name)
         .ok_or_else(|| serde::de::Error::custom(format!("group not found: '{}'", group_name)))
+}
+
+#[cfg(test)]
+mod tests {
+    #[derive(serde::Serialize, serde::Deserialize)]
+    struct S {
+        #[serde(
+            serialize_with = "crate::parser::syst_group::serialize",
+            deserialize_with = "crate::parser::syst_group::deserialize"
+        )]
+        v: users::Group,
+    }
+
+    #[test]
+    fn basic() {
+        assert_eq!(
+            serde_json::from_str::<S>("{\"v\":\"root\"}")
+                .unwrap()
+                .v
+                .gid(),
+            users::get_group_by_name("root").unwrap().gid()
+        );
+
+        assert_eq!(
+            "{\"v\":\"root\"}",
+            serde_json::to_string(&S {
+                v: users::get_group_by_name("root").unwrap()
+            })
+            .unwrap()
+        );
+    }
 }

--- a/vsmtp-config/src/parser/syst_user.rs
+++ b/vsmtp-config/src/parser/syst_user.rs
@@ -2,7 +2,7 @@ pub fn serialize<S: serde::Serializer>(
     value: &users::User,
     serializer: S,
 ) -> Result<S::Ok, S::Error> {
-    serde::Serialize::serialize(&value.name(), serializer)
+    serde::Serialize::serialize(&value.name().to_str().unwrap(), serializer)
 }
 
 pub fn deserialize<'de, D>(deserializer: D) -> Result<users::User, D::Error>
@@ -12,4 +12,35 @@ where
     let user_name = &<String as serde::Deserialize>::deserialize(deserializer)?;
     users::get_user_by_name(user_name)
         .ok_or_else(|| serde::de::Error::custom(format!("user not found: '{}'", user_name)))
+}
+
+#[cfg(test)]
+mod tests {
+    #[derive(serde::Serialize, serde::Deserialize)]
+    struct S {
+        #[serde(
+            serialize_with = "crate::parser::syst_user::serialize",
+            deserialize_with = "crate::parser::syst_user::deserialize"
+        )]
+        v: users::User,
+    }
+
+    #[test]
+    fn basic() {
+        assert_eq!(
+            serde_json::from_str::<S>("{\"v\":\"root\"}")
+                .unwrap()
+                .v
+                .uid(),
+            users::get_user_by_name("root").unwrap().uid()
+        );
+
+        assert_eq!(
+            "{\"v\":\"root\"}",
+            serde_json::to_string(&S {
+                v: users::get_user_by_name("root").unwrap()
+            })
+            .unwrap()
+        );
+    }
 }

--- a/vsmtp-config/src/parser/tls_cipher_suite.rs
+++ b/vsmtp-config/src/parser/tls_cipher_suite.rs
@@ -1,0 +1,150 @@
+use vsmtp_common::re::anyhow;
+
+/*
+const ALL_CIPHER_SUITE: [rustls::CipherSuite; 9] = [
+    // TLS1.3 suites
+    rustls::CipherSuite::TLS13_AES_256_GCM_SHA384,
+    rustls::CipherSuite::TLS13_AES_128_GCM_SHA256,
+    rustls::CipherSuite::TLS13_CHACHA20_POLY1305_SHA256,
+    // TLS1.2 suites
+    rustls::CipherSuite::TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+    rustls::CipherSuite::TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+    rustls::CipherSuite::TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
+    rustls::CipherSuite::TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+    rustls::CipherSuite::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+    rustls::CipherSuite::TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+];
+*/
+
+struct CipherSuite(rustls::CipherSuite);
+
+impl std::str::FromStr for CipherSuite {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "TLS_AES_256_GCM_SHA384" => Ok(Self(rustls::CipherSuite::TLS13_AES_256_GCM_SHA384)),
+            "TLS_AES_128_GCM_SHA256" => Ok(Self(rustls::CipherSuite::TLS13_AES_128_CCM_8_SHA256)),
+            "TLS_CHACHA20_POLY1305_SHA256" => {
+                Ok(Self(rustls::CipherSuite::TLS13_CHACHA20_POLY1305_SHA256))
+            }
+            "ECDHE_ECDSA_WITH_AES_256_GCM_SHA384" => Ok(Self(
+                rustls::CipherSuite::TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+            )),
+            "ECDHE_ECDSA_WITH_AES_128_GCM_SHA256" => Ok(Self(
+                rustls::CipherSuite::TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+            )),
+            "ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256" => Ok(Self(
+                rustls::CipherSuite::TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
+            )),
+            "ECDHE_RSA_WITH_AES_256_GCM_SHA384" => Ok(Self(
+                rustls::CipherSuite::TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+            )),
+            "ECDHE_RSA_WITH_AES_128_GCM_SHA256" => Ok(Self(
+                rustls::CipherSuite::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+            )),
+            "ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256" => Ok(Self(
+                rustls::CipherSuite::TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+            )),
+            _ => Err(anyhow::anyhow!("not a valid cipher suite: '{}'", s)),
+        }
+    }
+}
+
+impl std::fmt::Display for CipherSuite {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self.0 {
+            rustls::CipherSuite::TLS13_AES_256_GCM_SHA384 => "TLS_AES_256_GCM_SHA384",
+            rustls::CipherSuite::TLS13_AES_128_GCM_SHA256 => "TLS_AES_128_GCM_SHA256",
+            rustls::CipherSuite::TLS13_CHACHA20_POLY1305_SHA256 => "TLS_CHACHA20_POLY1305_SHA256",
+            rustls::CipherSuite::TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384 => {
+                "ECDHE_ECDSA_WITH_AES_256_GCM_SHA384"
+            }
+            rustls::CipherSuite::TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256 => {
+                "ECDHE_ECDSA_WITH_AES_128_GCM_SHA256"
+            }
+            rustls::CipherSuite::TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256 => {
+                "ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256"
+            }
+            rustls::CipherSuite::TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 => {
+                "ECDHE_RSA_WITH_AES_256_GCM_SHA384"
+            }
+            rustls::CipherSuite::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 => {
+                "ECDHE_RSA_WITH_AES_128_GCM_SHA256"
+            }
+            rustls::CipherSuite::TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256 => {
+                "ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256"
+            }
+            _ => "unsupported",
+        })
+    }
+}
+
+impl serde::Serialize for CipherSuite {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&format!("{}", self))
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for CipherSuite {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        <Self as std::str::FromStr>::from_str(&<String as serde::Deserialize>::deserialize(
+            deserializer,
+        )?)
+        .map_err(serde::de::Error::custom)
+    }
+}
+
+pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<rustls::CipherSuite>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    struct Visitor;
+
+    impl<'de> serde::de::Visitor<'de> for Visitor {
+        type Value = Vec<CipherSuite>;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            formatter.write_str("[...]")
+        }
+
+        fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+        where
+            A: serde::de::SeqAccess<'de>,
+        {
+            let mut v = Vec::<Result<CipherSuite, A::Error>>::new();
+            while let Some(i) = seq.next_element::<&str>()? {
+                v.push(
+                    <CipherSuite as std::str::FromStr>::from_str(i)
+                        .map_err(serde::de::Error::custom),
+                );
+            }
+
+            v.into_iter()
+                .collect::<Result<Vec<CipherSuite>, A::Error>>()
+        }
+    }
+
+    Ok(deserializer
+        .deserialize_any(Visitor)?
+        .into_iter()
+        .map(|i| i.0)
+        .collect::<Vec<_>>())
+}
+
+pub fn serialize<S>(this: &[rustls::CipherSuite], serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    let mut seq = serializer.serialize_seq(Some(this.len()))?;
+    for i in this {
+        serde::ser::SerializeSeq::serialize_element(&mut seq, &CipherSuite(*i))?;
+    }
+    serde::ser::SerializeSeq::end(seq)
+}

--- a/vsmtp-config/src/parser/tls_cipher_suite.rs
+++ b/vsmtp-config/src/parser/tls_cipher_suite.rs
@@ -24,7 +24,7 @@ impl std::str::FromStr for CipherSuite {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "TLS_AES_256_GCM_SHA384" => Ok(Self(rustls::CipherSuite::TLS13_AES_256_GCM_SHA384)),
-            "TLS_AES_128_GCM_SHA256" => Ok(Self(rustls::CipherSuite::TLS13_AES_128_CCM_8_SHA256)),
+            "TLS_AES_128_GCM_SHA256" => Ok(Self(rustls::CipherSuite::TLS13_AES_128_GCM_SHA256)),
             "TLS_CHACHA20_POLY1305_SHA256" => {
                 Ok(Self(rustls::CipherSuite::TLS13_CHACHA20_POLY1305_SHA256))
             }
@@ -147,4 +147,93 @@ where
         serde::ser::SerializeSeq::serialize_element(&mut seq, &CipherSuite(*i))?;
     }
     serde::ser::SerializeSeq::end(seq)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::parser::tls_cipher_suite::CipherSuite;
+
+    #[derive(serde::Serialize, serde::Deserialize)]
+    struct S {
+        #[serde(
+            serialize_with = "crate::parser::tls_cipher_suite::serialize",
+            deserialize_with = "crate::parser::tls_cipher_suite::deserialize"
+        )]
+        v: Vec<rustls::CipherSuite>,
+    }
+
+    #[test]
+    fn error() {
+        assert!(toml::from_str::<S>(r#"v = ["SRP_SHA_WITH_AES_128_CBC_SHA"]"#).is_err());
+        assert!(toml::from_str::<S>(r#"v = "foobar""#).is_err());
+        assert!(toml::from_str::<S>(r#"v = 100"#).is_err());
+    }
+
+    #[test]
+    fn tls1_3() {
+        assert_eq!(
+            toml::from_str::<S>(
+                r#"v = [
+    "TLS_AES_256_GCM_SHA384",
+    "TLS_AES_128_GCM_SHA256",
+    "TLS_CHACHA20_POLY1305_SHA256"
+]"#
+            )
+            .unwrap()
+            .v,
+            vec![
+                rustls::CipherSuite::TLS13_AES_256_GCM_SHA384,
+                rustls::CipherSuite::TLS13_AES_128_GCM_SHA256,
+                rustls::CipherSuite::TLS13_CHACHA20_POLY1305_SHA256,
+            ]
+        );
+    }
+
+    #[test]
+    fn tls1_2() {
+        assert_eq!(
+            toml::from_str::<S>(
+                r#"v = [
+    "ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+    "ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+    "ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256",
+    "ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+    "ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+    "ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
+]"#
+            )
+            .unwrap()
+            .v,
+            vec![
+                rustls::CipherSuite::TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+                rustls::CipherSuite::TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+                rustls::CipherSuite::TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
+                rustls::CipherSuite::TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+                rustls::CipherSuite::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+                rustls::CipherSuite::TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+            ]
+        );
+    }
+
+    const ALL_CIPHER_SUITE: [rustls::CipherSuite; 9] = [
+        rustls::CipherSuite::TLS13_AES_256_GCM_SHA384,
+        rustls::CipherSuite::TLS13_AES_128_GCM_SHA256,
+        rustls::CipherSuite::TLS13_CHACHA20_POLY1305_SHA256,
+        rustls::CipherSuite::TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+        rustls::CipherSuite::TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+        rustls::CipherSuite::TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
+        rustls::CipherSuite::TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+        rustls::CipherSuite::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+        rustls::CipherSuite::TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+    ];
+
+    #[test]
+    fn serialize() {
+        for i in ALL_CIPHER_SUITE {
+            assert_eq!(
+                serde_json::to_string(&S { v: vec![i] }).unwrap(),
+                format!("{{\"v\":[\"{}\"]}}", CipherSuite(i))
+            );
+        }
+    }
 }

--- a/vsmtp-config/src/tests/mod.rs
+++ b/vsmtp-config/src/tests/mod.rs
@@ -64,6 +64,7 @@ fn construct() {
                 certificate: rustls::Certificate(vec![]),
                 private_key: rustls::PrivateKey(vec![]),
                 sni: vec![],
+                cipher_suite: vec![],
             }),
             smtp: ConfigServerSMTP {
                 rcpt_count_max: 1000,

--- a/vsmtp-delivery/Cargo.toml
+++ b/vsmtp-delivery/Cargo.toml
@@ -24,9 +24,6 @@ time = { version = "0.3.7", default-features = false, features = [
     "macros",
 ] }
 
-anyhow = "1.0.56"
-log = "0.4.14"
-
 users = { version = "0.11.0", features = [] }
 trust-dns-resolver = "0.21.1"
 lettre = { version = "0.10.0-rc.4", default-features = false, features = [

--- a/vsmtp-delivery/src/lib.rs
+++ b/vsmtp-delivery/src/lib.rs
@@ -32,7 +32,7 @@ pub mod transport {
     use anyhow::Context;
     use lettre::Tokio1Executor;
     use trust_dns_resolver::TokioAsyncResolver;
-    use vsmtp_common::{address::Address, mail_context::MessageMetadata, rcpt::Rcpt};
+    use vsmtp_common::{address::Address, mail_context::MessageMetadata, rcpt::Rcpt, re::anyhow};
     use vsmtp_config::Config;
 
     /// allowing the [ServerVSMTP] to deliver a mail.

--- a/vsmtp-delivery/src/transport/deliver.rs
+++ b/vsmtp-delivery/src/transport/deliver.rs
@@ -18,7 +18,12 @@ use super::Transport;
 
 use anyhow::Context;
 use trust_dns_resolver::TokioAsyncResolver;
-use vsmtp_common::{mail_context::MessageMetadata, rcpt::Rcpt, transfer::EmailTransferStatus};
+use vsmtp_common::{
+    mail_context::MessageMetadata,
+    rcpt::Rcpt,
+    re::{anyhow, log},
+    transfer::EmailTransferStatus,
+};
 use vsmtp_config::Config;
 
 /// the email will be forwarded to another mail exchanger via mx record resolution & smtp.

--- a/vsmtp-delivery/src/transport/forward.rs
+++ b/vsmtp-delivery/src/transport/forward.rs
@@ -19,7 +19,12 @@ use super::Transport;
 use anyhow::Context;
 use trust_dns_resolver::TokioAsyncResolver;
 // use anyhow::Context;
-use vsmtp_common::{mail_context::MessageMetadata, rcpt::Rcpt, transfer::EmailTransferStatus};
+use vsmtp_common::{
+    mail_context::MessageMetadata,
+    rcpt::Rcpt,
+    re::{anyhow, log},
+    transfer::EmailTransferStatus,
+};
 use vsmtp_config::Config;
 
 /// the email will be directly delivered to the server, without mx lookup.

--- a/vsmtp-delivery/src/transport/mbox.rs
+++ b/vsmtp-delivery/src/transport/mbox.rs
@@ -19,7 +19,10 @@ use super::Transport;
 use anyhow::Context;
 use trust_dns_resolver::TokioAsyncResolver;
 use vsmtp_common::{
-    libc_abstraction::chown, mail_context::MessageMetadata, rcpt::Rcpt,
+    libc_abstraction::chown,
+    mail_context::MessageMetadata,
+    rcpt::Rcpt,
+    re::{anyhow, log},
     transfer::EmailTransferStatus,
 };
 use vsmtp_config::{log_channel::DELIVER, Config};

--- a/vsmtp-rule-engine/Cargo.toml
+++ b/vsmtp-rule-engine/Cargo.toml
@@ -18,7 +18,6 @@ vsmtp-config = { version = "^0.9", path = "../vsmtp-config" }
 
 serde_json = "1.0.79"
 
-addr = { version = "0.15.3" }
 regex = "1.5.5"
 iprange = "0.6.7"
 ipnet = "2.4.0"

--- a/vsmtp-rule-engine/src/obj.rs
+++ b/vsmtp-rule-engine/src/obj.rs
@@ -16,7 +16,7 @@
 **/
 use vsmtp_common::{
     address::Address,
-    re::{anyhow, log},
+    re::{addr, anyhow, log},
 };
 
 /// Objects are rust's representation of rule engine variables.

--- a/vsmtp-server/src/auth.rs
+++ b/vsmtp-server/src/auth.rs
@@ -1,34 +1,55 @@
 use vsmtp_common::re::rsasl;
 
-#[allow(clippy::module_name_repetitions)]
-pub struct AuthCallback;
+pub type Backend = rsasl::DiscardOnDrop<rsasl::SASL<(), ()>>;
 
-impl rsasl::Callback<(), ()> for AuthCallback {
+pub struct Callback;
+
+impl rsasl::Callback<(), ()> for Callback {
     fn callback(
         _sasl: &mut rsasl::SASL<(), ()>,
         session: &mut rsasl::Session<()>,
         prop: rsasl::Property,
     ) -> Result<(), rsasl::ReturnCode> {
+        // FIXME: this db MUST be provided by the rule engine
+        // which authorize the credentials or lookup a database (sql/ldap/...)
+        // or call an external services (saslauthd) for example
+        let db = [("hello", "world"), ("héllo", "wÖrld")]
+            .into_iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect::<std::collections::HashMap<String, String>>();
+
         match prop {
-            rsasl::Property::GSASL_VALIDATE_SIMPLE => {
-                // Access the authentication id, i.e. the username to check the password for
-                let authcid = session
+            rsasl::Property::GSASL_PASSWORD => {
+                let authid = session
                     .get_property(rsasl::Property::GSASL_AUTHID)
                     .ok_or(rsasl::ReturnCode::GSASL_NO_AUTHID)?
                     .to_str()
                     .unwrap()
                     .to_string();
 
-                // Access the password itself
-                let password = session
-                    .get_property(rsasl::Property::GSASL_PASSWORD)
-                    .ok_or(rsasl::ReturnCode::GSASL_NO_PASSWORD)?
-                    .to_str()
-                    .unwrap()
-                    .to_string();
+                if let Some(pass) = db.get(&authid) {
+                    session.set_property(rsasl::Property::GSASL_PASSWORD, pass.as_bytes());
+                }
 
-                // For brevity sake we use hard-coded credentials here.
-                if authcid == "hél=lo" && password == "wÖrld" {
+                Ok(())
+            }
+            rsasl::Property::GSASL_VALIDATE_SIMPLE => {
+                let (authid, password) = (
+                    session
+                        .get_property(rsasl::Property::GSASL_AUTHID)
+                        .ok_or(rsasl::ReturnCode::GSASL_NO_AUTHID)?
+                        .to_str()
+                        .unwrap()
+                        .to_string(),
+                    session
+                        .get_property(rsasl::Property::GSASL_PASSWORD)
+                        .ok_or(rsasl::ReturnCode::GSASL_NO_PASSWORD)?
+                        .to_str()
+                        .unwrap()
+                        .to_string(),
+                );
+
+                if db.get(&authid).map_or(false, |p| *p == password) {
                     Ok(())
                 } else {
                     Err(rsasl::ReturnCode::GSASL_AUTHENTICATION_ERROR)

--- a/vsmtp-server/src/receiver/auth_exchange.rs
+++ b/vsmtp-server/src/receiver/auth_exchange.rs
@@ -1,5 +1,6 @@
+use crate::auth;
+
 use super::Connection;
-use crate::server::SaslBackend;
 use vsmtp_common::{
     auth::Mechanism,
     code::SMTPReplyCode,
@@ -73,7 +74,7 @@ where
 
 pub async fn on_authentication<S>(
     conn: &mut Connection<'_, S>,
-    rsasl: std::sync::Arc<tokio::sync::Mutex<SaslBackend>>,
+    rsasl: std::sync::Arc<tokio::sync::Mutex<auth::Backend>>,
     mechanism: Mechanism,
     initial_response: Option<Vec<u8>>,
 ) -> Result<(), AuthExchangeError>

--- a/vsmtp-server/src/receiver/test_helpers.rs
+++ b/vsmtp-server/src/receiver/test_helpers.rs
@@ -15,12 +15,12 @@
  *
 */
 use crate::{
+    auth,
     receiver::{
         connection::{Connection, ConnectionKind},
         handle_connection,
         io_service::IoService,
     },
-    server::SaslBackend,
 };
 use anyhow::Context;
 use vsmtp_common::re::anyhow;
@@ -91,7 +91,7 @@ pub async fn test_receiver_deprecated<M>(
     smtp_input: &[u8],
     expected_output: &[u8],
     config: std::sync::Arc<Config>,
-    rsasl: Option<std::sync::Arc<tokio::sync::Mutex<SaslBackend>>>,
+    rsasl: Option<std::sync::Arc<tokio::sync::Mutex<auth::Backend>>>,
 ) -> anyhow::Result<()>
 where
     M: super::OnMail + Send,


### PR DESCRIPTION
* bump log 0.4.14 => 0.4.16
* minor re-implementation for readability
* vsmtp-common re-export addr
* add test for serialization / print of few untested data type
* fix the auth builder for the tests
* add a cipher_suite serialization
* simplify the sasl callback
* rename auth mod for clarity