### PR TITLE
Object Syntax

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2084,7 +2084,7 @@ dependencies = [
 
 [[package]]
 name = "vsmtp-delivery"
-version = "0.9.3"
+version = "0.9.7"
 dependencies = [
  "async-trait",
  "lettre",

--- a/vsmtp-delivery/Cargo.toml
+++ b/vsmtp-delivery/Cargo.toml
@@ -2,7 +2,7 @@
 edition = "2021"
 
 name = "vsmtp-delivery"
-version = "0.9.3"
+version = "0.9.7"
 license = "GPLv3"
 
 authors = ["Team viridIT <https://viridit.com/>"]

--- a/vsmtp-rule-engine/src/dsl/action_parsing.rs
+++ b/vsmtp-rule-engine/src/dsl/action_parsing.rs
@@ -1,0 +1,66 @@
+use crate::{error::RuleEngineError, modules::EngineResult};
+
+pub fn parse_action(
+    symbols: &[rhai::ImmutableString],
+    look_ahead: &str,
+) -> Result<Option<rhai::ImmutableString>, rhai::ParseError> {
+    match symbols.len() {
+        // action keyword ...
+        1 => Ok(Some("$string$".into())),
+        // name of the action ...
+        2 => Ok(Some("$expr$".into())),
+        // block, we are done parsing.
+        3 => Ok(None),
+        _ => Err(rhai::ParseError(
+            Box::new(rhai::ParseErrorType::BadInput(
+                rhai::LexError::UnexpectedInput(format!(
+                    "Improper action declaration: keyword '{}' unknown.",
+                    look_ahead
+                )),
+            )),
+            rhai::Position::NONE,
+        )),
+    }
+}
+
+pub fn create_action(
+    context: &mut rhai::EvalContext,
+    input: &[rhai::Expression],
+) -> EngineResult<rhai::Dynamic> {
+    let name = input[0]
+        .get_literal_value::<rhai::ImmutableString>()
+        .unwrap();
+    let expr = context.eval_expression_tree(&input[1])?;
+
+    Ok(rhai::Dynamic::from(
+        [
+            ("name".into(), rhai::Dynamic::from(name.clone())),
+            ("type".into(), "action".into()),
+        ]
+        .into_iter()
+        .chain(if expr.is::<rhai::Map>() {
+            let properties = expr.cast::<rhai::Map>();
+
+            if properties
+                .get("evaluate")
+                .filter(|f| f.is::<rhai::FnPtr>())
+                .is_none()
+            {
+                return Err(
+                    format!("'evaluate' function is missing from '{}' action", name).into(),
+                );
+            }
+
+            properties.into_iter()
+        } else if expr.is::<rhai::FnPtr>() {
+            rhai::Map::from_iter([("evaluate".into(), expr)]).into_iter()
+        } else {
+            return Err(format!(
+                "an action must be a rhai::Map (#{{}}) or an anonymous function (|| {{}}){}",
+                RuleEngineError::Action.as_str()
+            )
+            .into());
+        })
+        .collect::<rhai::Map>(),
+    ))
+}

--- a/vsmtp-rule-engine/src/dsl/mod.rs
+++ b/vsmtp-rule-engine/src/dsl/mod.rs
@@ -1,0 +1,3 @@
+pub mod action_parsing;
+pub mod object_parsing;
+pub mod rule_parsing;

--- a/vsmtp-rule-engine/src/dsl/object_parsing.rs
+++ b/vsmtp-rule-engine/src/dsl/object_parsing.rs
@@ -1,0 +1,168 @@
+use crate::error::RuleEngineError;
+use crate::modules::EngineResult;
+use crate::obj::Object;
+/// check of a "object" expression is valid.
+/// the syntax is:
+///   object $name$ $type[:file_type]$ = #{ value: "...", ... };
+///   object $name$ $type[:file_type]$ = "...";
+pub fn parse_object(
+    symbols: &[rhai::ImmutableString],
+    look_ahead: &str,
+) -> Result<Option<rhai::ImmutableString>, rhai::ParseError> {
+    match symbols.len() {
+        // object keyword, then the name of the object.
+        1 | 2 => Ok(Some("$ident$".into())),
+        // type of the object.
+        3 => match symbols[2].as_str() {
+            // regular type, next is the '=' token or ':' token in case of the file type.
+            "ip4" | "ip6" | "rg4" | "rg6" | "fqdn" | "address" | "ident" | "string" | "regex"
+            | "group" | "file" => Ok(Some("$symbol$".into())),
+            entry => Err(rhai::ParseError(
+                Box::new(rhai::ParseErrorType::BadInput(
+                    rhai::LexError::ImproperSymbol(
+                        entry.into(),
+                        format!("Improper object type '{}'.", entry),
+                    ),
+                )),
+                rhai::Position::NONE,
+            )),
+        },
+        4 => match symbols[3].as_str() {
+            // ':' token for a file content type, next is the content type of the file.
+            ":" => Ok(Some("$ident$".into())),
+            // '=' token for another object type, next is the content of the object.
+            "=" => Ok(Some("$expr$".into())),
+            entry => Err(rhai::ParseError(
+                Box::new(rhai::ParseErrorType::BadInput(
+                    rhai::LexError::ImproperSymbol(
+                        entry.into(),
+                        "Improper symbol when parsing object".to_string(),
+                    ),
+                )),
+                rhai::Position::NONE,
+            )),
+        },
+        5 => match symbols[4].as_str() {
+            // NOTE: could it be possible to add a "file" content type ?
+            // content types handled by the file type. next is the '=' token.
+            "ip4" | "ip6" | "rg4" | "rg6" | "fqdn" | "address" | "ident" | "string" | "regex" => {
+                Ok(Some("=".into()))
+            }
+            // an expression, in the case of a regular object, whe are done parsing.
+            _ => Ok(None),
+        },
+        6 => match symbols[5].as_str() {
+            // the '=' token, next is the path to the file or a map with it's value.
+            "=" => Ok(Some("$expr$".into())),
+            // map or string value for a regular type, we are done parsing.
+            _ => Ok(None),
+        },
+        7 => Ok(None),
+        _ => Err(rhai::ParseError(
+            Box::new(rhai::ParseErrorType::BadInput(
+                rhai::LexError::UnexpectedInput(format!(
+                    "Improper object declaration: keyword '{}' unknown.",
+                    look_ahead
+                )),
+            )),
+            rhai::Position::NONE,
+        )),
+    }
+}
+
+/// parses the given syntax tree and construct an object from it. always called after `parse_object`.
+pub fn create_object(
+    context: &mut rhai::EvalContext,
+    input: &[rhai::Expression],
+) -> EngineResult<rhai::Dynamic> {
+    let object_name = input[0].get_string_value().unwrap().to_string();
+    let object_type = input[1].get_string_value().unwrap().to_string();
+
+    let object = match object_type.as_str() {
+        "file" => create_file(context, input, &object_name),
+        _ => create_other(context, input, &object_type, &object_name),
+    }?;
+
+    let object_ptr = std::sync::Arc::new(
+        Object::from(&object)
+            .map_err::<Box<rhai::EvalAltResult>, _>(|err| err.to_string().into())?,
+    );
+
+    // Pushing object in scope, preventing a "let _" statement,
+    // and returning a reference to the object in case of a parent group.
+    // Also, exporting the variable by default using `set_alias`.
+    context
+        .scope_mut()
+        .push_constant(&object_name, object_ptr.clone())
+        .set_alias(object_name, "");
+
+    Ok(rhai::Dynamic::from(object_ptr))
+}
+
+/// create a file object as a Map.
+fn create_file(
+    context: &mut rhai::EvalContext,
+    input: &[rhai::Expression],
+    object_name: &str,
+) -> EngineResult<rhai::Map> {
+    let content_type = input[3].get_string_value().unwrap();
+    let object = context.eval_expression_tree(&input[4])?;
+
+    if object.is::<rhai::Map>() {
+        let mut object: rhai::Map = object.try_cast().ok_or(RuleEngineError::Object)?;
+        object.insert("type".into(), rhai::Dynamic::from("file"));
+        object.insert("name".into(), rhai::Dynamic::from(object_name.to_string()));
+        object.insert(
+            "content_type".into(),
+            rhai::Dynamic::from(content_type.to_string()),
+        );
+        Ok(object)
+    } else if object.is::<String>() {
+        let mut map = rhai::Map::new();
+        map.insert("type".into(), rhai::Dynamic::from("file"));
+        map.insert("name".into(), rhai::Dynamic::from(object_name.to_string()));
+        map.insert(
+            "content_type".into(),
+            rhai::Dynamic::from(content_type.to_string()),
+        );
+        map.insert("value".into(), object);
+        Ok(map)
+    } else {
+        return Err(rhai::EvalAltResult::ErrorMismatchDataType(
+            "Map | String".to_string(),
+            object.type_name().to_string(),
+            rhai::Position::NONE,
+        )
+        .into());
+    }
+}
+
+/// create a type other than file as a Map.
+fn create_other(
+    context: &mut rhai::EvalContext,
+    input: &[rhai::Expression],
+    object_type: &str,
+    object_name: &str,
+) -> EngineResult<rhai::Map> {
+    let object = context.eval_expression_tree(&input[3])?;
+
+    if object.is::<rhai::Map>() {
+        let mut object: rhai::Map = object.try_cast().ok_or(RuleEngineError::Object)?;
+        object.insert("type".into(), rhai::Dynamic::from(object_type.to_string()));
+        object.insert("name".into(), rhai::Dynamic::from(object_name.to_string()));
+        Ok(object)
+    } else if object.is::<String>() || object.is::<rhai::Array>() {
+        let mut map = rhai::Map::new();
+        map.insert("type".into(), rhai::Dynamic::from(object_type.to_string()));
+        map.insert("name".into(), rhai::Dynamic::from(object_name.to_string()));
+        map.insert("value".into(), object);
+        Ok(map)
+    } else {
+        return Err(rhai::EvalAltResult::ErrorMismatchDataType(
+            "Map | String".to_string(),
+            object.type_name().to_string(),
+            rhai::Position::NONE,
+        )
+        .into());
+    }
+}

--- a/vsmtp-rule-engine/src/dsl/rule_parsing.rs
+++ b/vsmtp-rule-engine/src/dsl/rule_parsing.rs
@@ -1,0 +1,64 @@
+use crate::{error::RuleEngineError, modules::EngineResult};
+
+pub fn parse_rule(
+    symbols: &[rhai::ImmutableString],
+    look_ahead: &str,
+) -> Result<Option<rhai::ImmutableString>, rhai::ParseError> {
+    match symbols.len() {
+        // rule keyword ...
+        1 => Ok(Some("$string$".into())),
+        // name of the rule ...
+        2 => Ok(Some("$expr$".into())),
+        // rhai::Map, we are done parsing.
+        3 => Ok(None),
+        _ => Err(rhai::ParseError(
+            Box::new(rhai::ParseErrorType::BadInput(
+                rhai::LexError::UnexpectedInput(format!(
+                    "Improper rule declaration: keyword '{}' unknown.",
+                    look_ahead
+                )),
+            )),
+            rhai::Position::NONE,
+        )),
+    }
+}
+
+pub fn create_rule(
+    context: &mut rhai::EvalContext,
+    input: &[rhai::Expression],
+) -> EngineResult<rhai::Dynamic> {
+    let name = input[0]
+        .get_literal_value::<rhai::ImmutableString>()
+        .unwrap();
+    let expr = context.eval_expression_tree(&input[1])?;
+
+    Ok(rhai::Dynamic::from(
+        [
+            ("name".into(), rhai::Dynamic::from(name.clone())),
+            ("type".into(), "rule".into()),
+        ]
+        .into_iter()
+        .chain(if expr.is::<rhai::Map>() {
+            let properties = expr.cast::<rhai::Map>();
+
+            if properties
+                .get("evaluate")
+                .filter(|f| f.is::<rhai::FnPtr>())
+                .is_none()
+            {
+                return Err(format!("'evaluate' function is missing from '{}' rule", name).into());
+            }
+
+            properties.into_iter()
+        } else if expr.is::<rhai::FnPtr>() {
+            rhai::Map::from_iter([("evaluate".into(), expr)]).into_iter()
+        } else {
+            return Err(format!(
+                "a rule must be a rhai::Map (#{{}}) or an anonymous function (|| {{}})\n{}",
+                RuleEngineError::Rule.as_str()
+            )
+            .into());
+        })
+        .collect::<rhai::Map>(),
+    ))
+}

--- a/vsmtp-rule-engine/src/lib.rs
+++ b/vsmtp-rule-engine/src/lib.rs
@@ -10,22 +10,7 @@
 //
 #![allow(clippy::doc_markdown)]
 
-/**
- * vSMTP mail transfer agent
- * Copyright (C) 2022 viridIT SAS
- *
- * This program is free software: you can redistribute it and/or modify it under
- * the terms of the GNU General Public License as published by the Free Software
- * Foundation, either version 3 of the License, or any later version.
- *
- *  This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along with
- * this program. If not, see https://www.gnu.org/licenses/.
- *
-**/
+mod dsl;
 mod error;
 /// vsl prelude
 pub mod modules;

--- a/vsmtp-rule-engine/src/obj.rs
+++ b/vsmtp-rule-engine/src/obj.rs
@@ -233,6 +233,7 @@ mod test {
     use super::Object;
 
     #[test]
+    #[allow(clippy::too_many_lines)]
     fn test_from() {
         let ip4 = Object::from(&rhai::Map::from_iter([
             ("name".into(), rhai::Dynamic::from("ip4".to_string())),

--- a/vsmtp-rule-engine/src/obj.rs
+++ b/vsmtp-rule-engine/src/obj.rs
@@ -226,3 +226,125 @@ impl ToString for Object {
         }
     }
 }
+
+#[cfg(test)]
+mod test {
+
+    use super::Object;
+
+    #[test]
+    fn test_from() {
+        let ip4 = Object::from(&rhai::Map::from_iter([
+            ("name".into(), rhai::Dynamic::from("ip4".to_string())),
+            ("type".into(), rhai::Dynamic::from("ip4".to_string())),
+            ("value".into(), rhai::Dynamic::from("127.0.0.1".to_string())),
+        ]))
+        .unwrap();
+
+        Object::from(&rhai::Map::from_iter([
+            ("ip6".into(), rhai::Dynamic::from("ip6".to_string())),
+            ("type".into(), rhai::Dynamic::from("ip6".to_string())),
+            (
+                "value".into(),
+                rhai::Dynamic::from("2001:0db8:0000:85a3:0000:0000:ac1f:8001".to_string()),
+            ),
+        ]))
+        .unwrap();
+
+        Object::from(&rhai::Map::from_iter([
+            ("name".into(), rhai::Dynamic::from("rg4".to_string())),
+            ("type".into(), rhai::Dynamic::from("rg4".to_string())),
+            (
+                "value".into(),
+                rhai::Dynamic::from("192.168.0.0/24".to_string()),
+            ),
+        ]))
+        .unwrap();
+
+        let rg6 = Object::from(&rhai::Map::from_iter([
+            ("name".into(), rhai::Dynamic::from("rg6".to_string())),
+            ("type".into(), rhai::Dynamic::from("rg6".to_string())),
+            (
+                "value".into(),
+                rhai::Dynamic::from("2001:db8:1234::/48".to_string()),
+            ),
+        ]))
+        .unwrap();
+
+        let fqdn = Object::from(&rhai::Map::from_iter([
+            ("name".into(), rhai::Dynamic::from("fqdn".to_string())),
+            ("type".into(), rhai::Dynamic::from("fqdn".to_string())),
+            (
+                "value".into(),
+                rhai::Dynamic::from("example.com".to_string()),
+            ),
+        ]))
+        .unwrap();
+
+        Object::from(&rhai::Map::from_iter([
+            ("name".into(), rhai::Dynamic::from("address".to_string())),
+            ("type".into(), rhai::Dynamic::from("address".to_string())),
+            (
+                "value".into(),
+                rhai::Dynamic::from("john@doe.com".to_string()),
+            ),
+        ]))
+        .unwrap();
+
+        Object::from(&rhai::Map::from_iter([
+            ("name".into(), rhai::Dynamic::from("ident".to_string())),
+            ("type".into(), rhai::Dynamic::from("ident".to_string())),
+            ("value".into(), rhai::Dynamic::from("john".to_string())),
+        ]))
+        .unwrap();
+
+        Object::from(&rhai::Map::from_iter([
+            ("name".into(), rhai::Dynamic::from("string".to_string())),
+            ("type".into(), rhai::Dynamic::from("string".to_string())),
+            (
+                "value".into(),
+                rhai::Dynamic::from("a text string".to_string()),
+            ),
+        ]))
+        .unwrap();
+
+        Object::from(&rhai::Map::from_iter([
+            ("name".into(), rhai::Dynamic::from("regex".to_string())),
+            ("type".into(), rhai::Dynamic::from("regex".to_string())),
+            (
+                "value".into(),
+                rhai::Dynamic::from("^[a-z0-9.]+.com$".to_string()),
+            ),
+        ]))
+        .unwrap();
+
+        // TODO: test all possible content types.
+        Object::from(&rhai::Map::from_iter([
+            ("name".into(), rhai::Dynamic::from("file".to_string())),
+            ("type".into(), rhai::Dynamic::from("file".to_string())),
+            (
+                "content_type".into(),
+                rhai::Dynamic::from("address".to_string()),
+            ),
+            (
+                "value".into(),
+                rhai::Dynamic::from("./src/tests/types/address/whitelist.txt".to_string()),
+            ),
+        ]))
+        .unwrap();
+
+        Object::from(&rhai::Map::from_iter([
+            ("name".into(), rhai::Dynamic::from("group".to_string())),
+            ("type".into(), rhai::Dynamic::from("group".to_string())),
+            (
+                "value".into(),
+                rhai::Dynamic::from(rhai::Array::from_iter([
+                    rhai::Dynamic::from(std::sync::Arc::new(ip4)),
+                    rhai::Dynamic::from(std::sync::Arc::new(rg6)),
+                    rhai::Dynamic::from(std::sync::Arc::new(fqdn)),
+                ])),
+            ),
+        ]))
+        .unwrap();
+    }
+}

--- a/vsmtp-rule-engine/src/tests/email/bcc/main.vsl
+++ b/vsmtp-rule-engine/src/tests/email/bcc/main.vsl
@@ -3,12 +3,12 @@ import "bcc" as bcc;
 #{
     postq: [
         rule "bcc with invalid address (str)"       || bcc::invalid_object(ctx, "invalid-address"),
-        rule "bcc with invalid address (obj ident)" || bcc::invalid_object(ctx, object ident "green" "green.foo"),
-        rule "bcc with invalid address (obj str)"   || bcc::invalid_object(ctx, object string "invalid" "invalid-str-address"),
+        rule "bcc with invalid address (obj ident)" || bcc::invalid_object(ctx, object green ident = "green.foo"),
+        rule "bcc with invalid address (obj str)"   || bcc::invalid_object(ctx, object invalid string = "invalid-str-address"),
         rule "add bcc" || {
             if bcc::add_bcc(ctx, "string@address.com") == vsl::next()
-            && bcc::add_bcc(ctx, object string "str" "my.string@address.eu") == vsl::next()
-            && bcc::add_bcc(ctx, object address "addr" "my.addr@address.com") == vsl::next()
+            && bcc::add_bcc(ctx, object str string = "my.string@address.eu") == vsl::next()
+            && bcc::add_bcc(ctx, object addr address = "my.addr@address.com") == vsl::next()
             && bcc::add_bcc(ctx, vsl::new_address("new.address@address.fr")) == vsl::next()
             {
                 vsl::next()

--- a/vsmtp-rule-engine/src/tests/rules/helo/main.vsl
+++ b/vsmtp-rule-engine/src/tests/rules/helo/main.vsl
@@ -1,6 +1,6 @@
-object fqdn "bar" "example.com";
-object file:fqdn "domains" "./src/tests/rules/helo/helo.txt";
-object regex "com" "^[a-z0-9.]+.com$";
+object bar fqdn = "example.com";
+object domains file:fqdn = "./src/tests/rules/helo/helo.txt";
+object com regex = "^[a-z0-9.]+.com$";
 
 #{
   helo: [

--- a/vsmtp-rule-engine/src/tests/rules/mail/main.vsl
+++ b/vsmtp-rule-engine/src/tests/rules/mail/main.vsl
@@ -1,13 +1,13 @@
-object ident "john" "johndoe";
-object fqdn "bar" "example.com";
-object address "someone" "staff@example.com";
+object john ident = "johndoe";
+object bar fqdn = "example.com";
+object someone address = "staff@example.com";
 
-object group "staff" [
+object staff group = [
   john,
-  object address "green" "green@personal.eu",
-  object address "steven" "steven@personal.fr",
-  object address "staff" "staff@example.com",
-  object address "ruben" "ruben@email.ru",
+  object green address = "green@personal.eu",
+  object steven address = "steven@personal.fr",
+  object staff address = "staff@example.com",
+  object ruben address = "ruben@email.ru",
 ];
 
 #{

--- a/vsmtp-rule-engine/src/tests/rules/parsing/objects-parsing.vsl
+++ b/vsmtp-rule-engine/src/tests/rules/parsing/objects-parsing.vsl
@@ -2,12 +2,12 @@
 // define objects to use in rules.
 
 // standard object declaration.
-object ip4 "unspecified" #{
+object unspecified ip4 = #{
   value: "0.0.0.0",
   color: "bbf3ab"
 };
 
-object ip4 "localhost" #{
+object localhost ip4 = #{
   value: "127.0.0.1",
   color: "bbf3ab",
   description: "the localhost ip address"
@@ -16,27 +16,27 @@ object ip4 "localhost" #{
 // fully qualified domain name objects.
 // NOTE: objects can be declared in an inline manner.
 //       redefined objects are overwritten.
-object fqdn "inline_fqdn" "example.com";
-object fqdn "inline_fqdn" "xxx.com";
+object inline_fqdn fqdn = "example.com";
+object inline_fqdn fqdn = "xxx.com";
 // object fqdn "invalid_fqdn" "foobar..com";
 
 // variables, represent simple strings.
-object val "user_dev" "gitdev";
-object val "user_prod" "gitproduction";
-object val "user_test" "gittest";
+object user_dev val = "gitdev";
+object user_prod val = "gitproduction";
+object user_test val = "gittest";
 
 // email addresses.
-object address "jones" "jones@foo.com";
-object address "green" "green@example.com";
+object jones address = "jones@foo.com";
+object green address = "green@example.com";
 // object address "invalid" "abc/.com";
 
 // files object, format: `file:(content-type)`
 // content-type can be: ip4, ip6, rg4, rg6, fqdn, str, address or regex.
-object file:addr "whitelist" "./src/rules/tests/configs/whitelist.txt";
+object whitelist file:addr = "./src/rules/tests/configs/whitelist.txt";
 
 // regex objects.
-object regex "bar_staff" "^[a-z0-9.]+@example.com$";
-object regex "localhost_emails" "^[a-z0-9.]+@localhost$";
+object bar_staff regex = "^[a-z0-9.]+@example.com$";
+object localhost_emails regex = "^[a-z0-9.]+@localhost$";
 
 // group objects, can store references to other objects,
 // or store fresh objects.
@@ -44,13 +44,13 @@ object regex "localhost_emails" "^[a-z0-9.]+@localhost$";
 // when passed down into a check action, the whole group will
 // be tested. The test stops when one of the groups content
 // matches.
-object group "authorized_users" [
+object authorized_users group = [
   whitelist,
-  object ip4 "authorized_ip" "1.1.1.1",
+  object authorized_ip ip4 = "1.1.1.1",
 ];
 
 // groups can be nested into other groups.
-object group "deep_group" [
-  object regex "foo_emails" "^[a-z0-9.]+@foo.com$",
+object deep_group group = [
+  object foo_emails regex = "^[a-z0-9.]+@foo.com$",
   authorized_users,
 ];

--- a/vsmtp-rule-engine/src/tests/rules/rcpt/main.vsl
+++ b/vsmtp-rule-engine/src/tests/rules/rcpt/main.vsl
@@ -1,6 +1,6 @@
-object ident "john" "johndoe";
-object fqdn "bar" "example.com";
-object address "customer" "customer@company.com";
+object john ident = "johndoe";
+object bar fqdn = "example.com";
+object customer address = "customer@company.com";
 
 #{
   rcpt: [

--- a/vsmtp-rule-engine/src/tests/types/address/main.vsl
+++ b/vsmtp-rule-engine/src/tests/types/address/main.vsl
@@ -1,16 +1,16 @@
-object address "address_obj" "add@obj.net";
-object fqdn "fqdn_obj" "obj.net";
-object regex "regex_obj" "^[a-z0-9.]+@obj.com$";
-object file:address "file_obj" "./src/tests/types/address/whitelist.txt";
+object address_obj address = "add@obj.net";
+object fqdn_obj fqdn = "obj.net";
+object regex_obj regex = "^[a-z0-9.]+@obj.com$";
+object file_obj file:address = "./src/tests/types/address/whitelist.txt";
 
-object group "group_obj" [
+object group_obj group = [
     address_obj,
     regex_obj,
-    object address "nested_address" "nested@address.com",
+    object nested_address address = "nested@address.com",
 ];
 
-object ident "identifier_obj" "local_part";
-object string "string_obj" "raw@address.net";
+object identifier_obj ident = "local_part";
+object string_obj string = "raw@address.net";
 
 #{
     connect: [
@@ -90,12 +90,12 @@ object string "string_obj" "raw@address.net";
 
         rule "test_not_valid_comparison" || {
             try {
-                vsl::new_address("raw@address.net") is object ip4 "ip" "127.0.0.1";
+                vsl::new_address("raw@address.net") is object ip ip4 = "127.0.0.1";
                 return vsl::deny();
             } catch {}
 
             try {
-                vsl::new_address("raw@address.net") in object address "in_addr" "impossible@test.com";
+                vsl::new_address("raw@address.net") in object in_addr address = "impossible@test.com";
                 return vsl::deny();
             } catch {}
 

--- a/vsmtp-rule-engine/src/tests/types/objects/vars.vsl
+++ b/vsmtp-rule-engine/src/tests/types/objects/vars.vsl
@@ -1,21 +1,21 @@
-object ip4 "ip4" "127.0.0.1";
-object ip6 "ip6" "0:0:0:0:0:0:0:1";
-object rg4 "rg4" "127.0.0.1/32";
-object rg6 "rg6" "0:0:0:0:0:0:0:1/32";
-object address "address" "local_part@domain.com";
-object fqdn "fqdn" "domain.com";
-object regex "regex" "^[a-z0-9.]+@domain.com$";
-object ident "identifier" "local_part";
-object string "str" "a string";
+object ip4 ip4 = "127.0.0.1";
+object ip6 ip6 = "0:0:0:0:0:0:0:1";
+object rg4 rg4 = "127.0.0.1/32";
+object rg6 rg6 = "0:0:0:0:0:0:0:1/32";
+object address address = "local_part@domain.com";
+object fqdn fqdn = "domain.com";
+object regex regex = "^[a-z0-9.]+@domain.com$";
+object identifier ident = "local_part";
+object str string = "a string";
 
-object file:address "file" "./src/tests/types/address/whitelist.txt";
-object group "group" [
+object file file:address = "./src/tests/types/address/whitelist.txt";
+object group group = [
     ip4,
     ip6,
     address,
     fqdn,
-    object ip4 "nested_ip4" "0.0.0.0",
-    object address "nested_addr" "nested@addr.com",
+    object nested_ip4 ip4 = "0.0.0.0",
+    object nested_addr address = "nested@addr.com",
 ];
 
 export ip4;


### PR DESCRIPTION
- update `object` syntax in vsl.

```rust
// old syntax
object ip4 "localhost" "127.0.0.1";

// new syntax -> object $name$ $type$ = "...";
object localhost ip4 = "127.0.0.1";
object graylist file:address = "/etc/graylist.txt";
object label string = #{
  value: "warning",
  color: "red",
};
```
- refactored rule engine parsing code.
- added more tests for object parsing.