### PR TITLE
Root domain parameters for virtual domains

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2092,7 +2092,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "vqueue"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "clap 3.1.10",
  "itertools",
@@ -2103,7 +2103,7 @@ dependencies = [
 
 [[package]]
 name = "vsmtp"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "clap 3.1.10",
  "diff",
@@ -2114,7 +2114,7 @@ dependencies = [
 
 [[package]]
 name = "vsmtp-common"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "addr",
  "anyhow",
@@ -2130,7 +2130,7 @@ dependencies = [
 
 [[package]]
 name = "vsmtp-config"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "hostname",
  "humantime-serde",
@@ -2149,7 +2149,7 @@ dependencies = [
 
 [[package]]
 name = "vsmtp-delivery"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "async-trait",
  "lettre",
@@ -2163,7 +2163,7 @@ dependencies = [
 
 [[package]]
 name = "vsmtp-mail-parser"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "pretty_assertions",
  "vsmtp-common",
@@ -2171,7 +2171,7 @@ dependencies = [
 
 [[package]]
 name = "vsmtp-rule-engine"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "ipnet",
  "iprange",
@@ -2188,7 +2188,7 @@ dependencies = [
 
 [[package]]
 name = "vsmtp-server"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "async-trait",
  "base64",
@@ -2215,7 +2215,7 @@ dependencies = [
 
 [[package]]
 name = "vsmtp-test"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "async-trait",
  "lettre",

--- a/examples/config/tls.toml
+++ b/examples/config/tls.toml
@@ -11,18 +11,20 @@ protocol_version = "TLSv1.3"
 certificate = "../examples/config/tls/certificate.crt"
 private_key = "../examples/config/tls/private_key.key"
 
-[server.virtual."testserver2.com"]
-dns = { type = "system" }
+[server.virtual."testserver1.com"]
 
-[server.virtual."testserver2.com".tls]
-protocol_version = "TLSv1.3"
-certificate = "../examples/config/tls/certificate.crt"
-private_key = "../examples/config/tls/private_key.key"
-
-[server.virtual."testserver3.com"]
-dns = { type = "system" }
+[server.virtual."testserver2.com".dns]
+type = "system"
 
 [server.virtual."testserver3.com".tls]
 protocol_version = "TLSv1.3"
 certificate = "../examples/config/tls/certificate.crt"
 private_key = "../examples/config/tls/private_key.key"
+
+[server.virtual."testserver4.com".tls]
+protocol_version = "TLSv1.3"
+certificate = "../examples/config/tls/certificate.crt"
+private_key = "../examples/config/tls/private_key.key"
+
+[server.virtual."testserver4.com".dns]
+type = "google"

--- a/vqueue/Cargo.toml
+++ b/vqueue/Cargo.toml
@@ -2,7 +2,7 @@
 edition = "2021"
 
 name = "vqueue"
-version = "0.10.1"
+version = "0.10.2"
 license = "GPLv3"
 
 authors = ["Team viridIT <https://viridit.com/>"]

--- a/vsmtp-common/Cargo.toml
+++ b/vsmtp-common/Cargo.toml
@@ -2,7 +2,7 @@
 edition = "2021"
 
 name = "vsmtp-common"
-version = "0.10.1"
+version = "0.10.2"
 license = "GPLv3"
 
 authors = ["Team viridIT <https://viridit.com/>"]

--- a/vsmtp-config/Cargo.toml
+++ b/vsmtp-config/Cargo.toml
@@ -2,7 +2,7 @@
 edition = "2021"
 
 name = "vsmtp-config"
-version = "0.10.1"
+version = "0.10.2"
 license = "GPLv3"
 
 authors = ["Team viridIT <https://viridit.com/>"]

--- a/vsmtp-config/src/tests/root_example/tls.rs
+++ b/vsmtp-config/src/tests/root_example/tls.rs
@@ -1,4 +1,4 @@
-use crate::{builder::VirtualEntry, Config};
+use crate::{builder::VirtualEntry, Config, ConfigServerDNS, ResolverOptsWrapper};
 
 #[test]
 fn parse() {
@@ -30,15 +30,33 @@ fn parse() {
             .with_system_dns()
             .with_virtual_entries(&[
                 VirtualEntry {
+                    domain: "testserver1.com".to_string(),
+                    tls: None,
+                    dns: None,
+                },
+                VirtualEntry {
                     domain: "testserver2.com".to_string(),
-                    certificate_path: "../examples/config/tls/certificate.crt".to_string(),
-                    private_key_path: "../examples/config/tls/private_key.key".to_string(),
+                    tls: None,
+                    dns: Some(ConfigServerDNS::System),
                 },
                 VirtualEntry {
                     domain: "testserver3.com".to_string(),
-                    certificate_path: "../examples/config/tls/certificate.crt".to_string(),
-                    private_key_path: "../examples/config/tls/private_key.key".to_string(),
-                }
+                    tls: Some((
+                        "../examples/config/tls/certificate.crt".to_string(),
+                        "../examples/config/tls/private_key.key".to_string()
+                    )),
+                    dns: None,
+                },
+                VirtualEntry {
+                    domain: "testserver4.com".to_string(),
+                    tls: Some((
+                        "../examples/config/tls/certificate.crt".to_string(),
+                        "../examples/config/tls/private_key.key".to_string()
+                    )),
+                    dns: Some(ConfigServerDNS::Google {
+                        options: ResolverOptsWrapper::default()
+                    }),
+                },
             ])
             .unwrap()
             .validate()

--- a/vsmtp-config/src/trust_dns_helper.rs
+++ b/vsmtp-config/src/trust_dns_helper.rs
@@ -56,8 +56,17 @@ pub fn build_resolvers(
         build_dns_from_config(&config.server.dns)?,
     );
 
+    // root domain dns config is used by default if it is not configured in the virtual domain.
     for (domain, domain_config) in &config.server.r#virtual {
-        resolvers.insert(domain.clone(), build_dns_from_config(&domain_config.dns)?);
+        resolvers.insert(
+            domain.clone(),
+            build_dns_from_config(
+                domain_config
+                    .dns
+                    .as_ref()
+                    .map_or(&config.server.dns, |dns_config| dns_config),
+            )?,
+        );
     }
 
     Ok(resolvers)

--- a/vsmtp-delivery/Cargo.toml
+++ b/vsmtp-delivery/Cargo.toml
@@ -2,7 +2,7 @@
 edition = "2021"
 
 name = "vsmtp-delivery"
-version = "0.10.1"
+version = "0.10.2"
 license = "GPLv3"
 
 authors = ["Team viridIT <https://viridit.com/>"]

--- a/vsmtp-delivery/src/lib.rs
+++ b/vsmtp-delivery/src/lib.rs
@@ -116,13 +116,19 @@ pub mod transport {
                 )
             }
             // or a domain from one of the virtual domains.
-            else if let Some(domain_config) = config.server.r#virtual.get(from.domain()) {
+            else if let Some(tls_config) = config
+                .server
+                .r#virtual
+                .get(from.domain())
+                .and_then(|domain| domain.tls.as_ref())
+            {
                 tls_builder.add_root_certificate(
                     lettre::transport::smtp::client::Certificate::from_der(
-                        domain_config.tls.certificate.0.clone(),
+                        tls_config.certificate.0.clone(),
                     )
                     .context("failed to parse certificate as der")?,
                 )
+            // if not, no certificate are used.
             } else {
                 tls_builder
             }

--- a/vsmtp-mail-parser/Cargo.toml
+++ b/vsmtp-mail-parser/Cargo.toml
@@ -2,7 +2,7 @@
 edition = "2021"
 
 name = "vsmtp-mail-parser"
-version = "0.10.1"
+version = "0.10.2"
 license = "GPLv3"
 
 authors = ["Team viridIT <https://viridit.com/>"]

--- a/vsmtp-rule-engine/Cargo.toml
+++ b/vsmtp-rule-engine/Cargo.toml
@@ -2,7 +2,7 @@
 edition = "2021"
 
 name = "vsmtp-rule-engine"
-version = "0.10.1"
+version = "0.10.2"
 license = "GPLv3"
 
 authors = ["Team viridIT <https://viridit.com/>"]

--- a/vsmtp-rule-engine/src/tests/types/mod.rs
+++ b/vsmtp-rule-engine/src/tests/types/mod.rs
@@ -21,7 +21,7 @@ use crate::{
 use vsmtp_common::{
     address::Address, collection, mail_context::Body, state::StateSMTP, status::Status,
 };
-use vsmtp_config::{builder::VirtualEntry, Config, Service};
+use vsmtp_config::{builder::VirtualEntry, Config, ConfigServerDNS, Service};
 
 #[test]
 fn test_status() {
@@ -157,14 +157,17 @@ fn test_config_display() {
         .with_system_dns()
         .with_virtual_entries(&[VirtualEntry {
             domain: "domain@example.com".to_string(),
-            certificate_path: root_example!["../config/tls/certificate.crt"]
-                .to_str()
-                .unwrap()
-                .to_string(),
-            private_key_path: root_example!["../config/tls/private_key.key"]
-                .to_str()
-                .unwrap()
-                .to_string(),
+            tls: Some((
+                root_example!["../config/tls/certificate.crt"]
+                    .to_str()
+                    .unwrap()
+                    .to_string(),
+                root_example!["../config/tls/private_key.key"]
+                    .to_str()
+                    .unwrap()
+                    .to_string(),
+            )),
+            dns: Some(ConfigServerDNS::System),
         }])
         .unwrap()
         .validate()

--- a/vsmtp-server/Cargo.toml
+++ b/vsmtp-server/Cargo.toml
@@ -2,7 +2,7 @@
 edition = "2021"
 
 name = "vsmtp-server"
-version = "0.10.1"
+version = "0.10.2"
 license = "GPLv3"
 
 authors = ["Team viridIT <https://viridit.com/>"]

--- a/vsmtp-server/src/processes/delivery.rs
+++ b/vsmtp-server/src/processes/delivery.rs
@@ -138,13 +138,13 @@ async fn send_email(
                 to,
                 resolvers
                     .get(to)
-                    .ok_or_else(|| anyhow::anyhow!("no dns configured for {to}"))?,
+                    .unwrap_or_else(|| resolvers.get(&config.server.domain).unwrap()),
             )),
             Transfer::Deliver => Box::new(deliver2::Deliver::new({
                 let domain = rcpt[0].address.domain();
                 resolvers
                     .get(domain)
-                    .ok_or_else(|| anyhow::anyhow!("no dns configured for {domain}"))?
+                    .unwrap_or_else(|| resolvers.get(&config.server.domain).unwrap())
             })),
             Transfer::Mbox => Box::new(mbox::MBox),
             Transfer::Maildir => Box::new(maildir::Maildir),

--- a/vsmtp-test/Cargo.toml
+++ b/vsmtp-test/Cargo.toml
@@ -2,7 +2,7 @@
 edition = "2021"
 
 name = "vsmtp-test"
-version = "0.10.1"
+version = "0.10.2"
 license = "GPLv3"
 
 authors = ["Team viridIT <https://viridit.com/>"]

--- a/vsmtp/Cargo.toml
+++ b/vsmtp/Cargo.toml
@@ -2,7 +2,7 @@
 edition = "2021"
 
 name = "vsmtp"
-version = "0.10.1"
+version = "0.10.2"
 license = "GPLv3"
 
 authors = ["Team viridIT <https://viridit.com/>"]


### PR DESCRIPTION
Virtual domains accept's dns & tls configurations. If those are not specified, the root domain's config is used instead.
```toml
# no parameters, all root domains parameters are used for testserver1.com.
[server.virtual."testserver1.com"]

# tls parameters for testserver2.com are the same as the root domain.
[server.virtual."testserver2.com".dns]
type = "system"

# dns parameters for testserver3.com are the same as the root domain.
[server.virtual."testserver3.com".tls]
protocol_version = "TLSv1.3"
certificate = "examples/config/tls/certificate.crt"
private_key = "examples/config/tls/private_key.key"

# testserver4.com has it's own parameters.
[server.virtual."testserver4.com".tls]
protocol_version = "TLSv1.3"
certificate = "examples/config/tls/certificate.crt"
private_key = "examples/config/tls/private_key.key"

[server.virtual."testserver4.com".dns]
type = "google"
```