### PR TITLE
Update queues initialization

### DIFF
--- a/vqueue/src/command/msg_command/remove.rs
+++ b/vqueue/src/command/msg_command/remove.rs
@@ -42,7 +42,9 @@ mod tests {
     fn confirmed() {
         let queues_dirpath = "./tmp/cmd_remove";
         let msg_id = "titi";
-        let filepath = Queue::Working.to_path(queues_dirpath).unwrap().join(msg_id);
+        let filepath =
+            vsmtp_common::queue_path!(create_if_missing => queues_dirpath, Queue::Working, msg_id)
+                .unwrap();
 
         std::fs::OpenOptions::new()
             .create(true)
@@ -66,7 +68,9 @@ mod tests {
     fn not_confirmed() {
         let queues_dirpath = "./tmp/cmd_remove";
         let msg_id = "tata";
-        let filepath = Queue::Working.to_path(queues_dirpath).unwrap().join(msg_id);
+        let filepath =
+            vsmtp_common::queue_path!(create_if_missing => queues_dirpath, Queue::Working, msg_id)
+                .unwrap();
 
         std::fs::OpenOptions::new()
             .create(true)
@@ -101,7 +105,9 @@ mod tests {
     fn canceled() {
         let queues_dirpath = "./tmp/cmd_remove";
         let msg_id = "tutu";
-        let filepath = Queue::Working.to_path(queues_dirpath).unwrap().join(msg_id);
+        let filepath =
+            vsmtp_common::queue_path!(create_if_missing => queues_dirpath, Queue::Working, msg_id)
+                .unwrap();
 
         std::fs::OpenOptions::new()
             .create(true)

--- a/vqueue/src/model.rs
+++ b/vqueue/src/model.rs
@@ -130,13 +130,17 @@ impl std::fmt::Display for QueueContent {
         ))?;
 
         if self.inner.is_empty() {
-            f.write_str(" <EMPTY>\n")?;
+            f.write_str(if self.dirpath.exists() {
+                " <EMPTY>\n"
+            } else {
+                " <MISSING>\n"
+            })?;
             return Ok(());
         }
 
         f.write_str("\n")?;
 
-        f.write_fmt(format_args!("{:>15}", "T"))?;
+        f.write_fmt(format_args!("{:>25}", "T"))?;
         for i in &lifetimes {
             f.write_fmt(format_args!("{i:>5}"))?;
         }
@@ -147,7 +151,7 @@ impl std::fmt::Display for QueueContent {
         f.write_fmt(format_args!("\n"))?;
 
         f.write_fmt(format_args!(
-            "{:>10}{:>5}",
+            "{:>20}{:>5}",
             "TOTAL",
             token_if_empty!(
                 self.empty_token,
@@ -180,7 +184,7 @@ impl std::fmt::Display for QueueContent {
 
         for (key, values) in &self.inner {
             f.write_fmt(format_args!(
-                "{key:>10}{:>5}",
+                "{key:>20}{:>5}",
                 token_if_empty!(
                     self.empty_token,
                     values.iter().fold(0, |sum, (_, m)| sum + m.len())

--- a/vsmtp-config/src/parser/tls_certificate.rs
+++ b/vsmtp-config/src/parser/tls_certificate.rs
@@ -79,6 +79,8 @@ mod tests {
 
     #[test]
     fn basic() {
+        let _droppable = std::fs::DirBuilder::new().create("./tmp");
+
         let mut file = std::fs::OpenOptions::new()
             .create(true)
             .write(true)

--- a/vsmtp-config/src/parser/tls_private_key.rs
+++ b/vsmtp-config/src/parser/tls_private_key.rs
@@ -84,6 +84,8 @@ mod tests {
 
     #[test]
     fn rsa_ok() {
+        let _droppable = std::fs::DirBuilder::new().create("./tmp");
+
         let mut file = std::fs::OpenOptions::new()
             .create(true)
             .write(true)
@@ -97,6 +99,8 @@ mod tests {
 
     #[test]
     fn pkcs8_ok() {
+        let _droppable = std::fs::DirBuilder::new().create("./tmp");
+
         let mut file = std::fs::OpenOptions::new()
             .create(true)
             .write(true)
@@ -110,6 +114,8 @@ mod tests {
 
     #[test]
     fn ec256_ok() {
+        let _droppable = std::fs::DirBuilder::new().create("./tmp");
+
         let mut file = std::fs::OpenOptions::new()
             .create(true)
             .write(true)
@@ -123,6 +129,8 @@ mod tests {
 
     #[test]
     fn not_good_format() {
+        let _droppable = std::fs::DirBuilder::new().create("./tmp");
+
         let mut file = std::fs::OpenOptions::new()
             .create(true)
             .write(true)

--- a/vsmtp-server/src/processes/delivery.rs
+++ b/vsmtp-server/src/processes/delivery.rs
@@ -27,6 +27,7 @@ use trust_dns_resolver::TokioAsyncResolver;
 use vsmtp_common::{
     mail_context::{Body, MailContext},
     queue::Queue,
+    queue_path,
     re::{anyhow, log},
     status::Status,
     transfer::{EmailTransferStatus, Transfer},
@@ -74,10 +75,7 @@ pub async fn start(
                 let copy_rule_engine = rule_engine.clone();
                 let copy_resolvers = resolvers.clone();
                 tokio::spawn(async move {
-                    let path = match Queue::Deliver.to_path(&copy_config.server.queues.dirpath) {
-                        Ok(path) => path,
-                        Err(_) => return // todo : log no file
-                    };
+                    let path = queue_path!(&copy_config.server.queues.dirpath, Queue::Deliver);
 
                     if let Err(error) = handle_one_in_delivery_queue(
                         &copy_config,

--- a/vsmtp-server/src/processes/delivery/deferred.rs
+++ b/vsmtp-server/src/processes/delivery/deferred.rs
@@ -3,6 +3,7 @@ use trust_dns_resolver::TokioAsyncResolver;
 use vsmtp_common::{
     mail_context::MailContext,
     queue::Queue,
+    queue_path,
     rcpt::Rcpt,
     re::{
         anyhow::{self, Context},
@@ -16,7 +17,8 @@ pub async fn flush_deferred_queue(
     config: &Config,
     resolvers: &std::collections::HashMap<String, TokioAsyncResolver>,
 ) -> anyhow::Result<()> {
-    let dir_entries = std::fs::read_dir(Queue::Deferred.to_path(&config.server.queues.dirpath)?)?;
+    let dir_entries =
+        std::fs::read_dir(queue_path!(&config.server.queues.dirpath, Queue::Deferred))?;
     for path in dir_entries {
         if let Err(e) = handle_one_in_deferred_queue(config, resolvers, &path?.path()).await {
             log::warn!("{}", e);

--- a/vsmtp-server/src/processes/mime.rs
+++ b/vsmtp-server/src/processes/mime.rs
@@ -19,6 +19,7 @@ use anyhow::Context;
 use vsmtp_common::{
     mail_context::MailContext,
     queue::Queue,
+    queue_path,
     re::{anyhow, log},
     state::StateSMTP,
     status::Status,
@@ -68,9 +69,11 @@ async fn handle_one_in_working_queue(
         process_message.message_id,
     );
 
-    let file_to_process = Queue::Working
-        .to_path(&config.server.queues.dirpath)?
-        .join(&process_message.message_id);
+    let file_to_process = queue_path!(
+        &config.server.queues.dirpath,
+        Queue::Working,
+        &process_message.message_id
+    );
 
     log::debug!(target: DELIVER, "vMIME opening file: {:?}", file_to_process);
 

--- a/vsmtp-server/src/runtime.rs
+++ b/vsmtp-server/src/runtime.rs
@@ -2,9 +2,12 @@ use crate::{
     processes::{delivery, mime},
     ProcessMessage, Server,
 };
-use vsmtp_common::re::{
-    anyhow::{self, Context},
-    log,
+use vsmtp_common::{
+    queue::Queue,
+    re::{
+        anyhow::{self, Context},
+        log, strum,
+    },
 };
 use vsmtp_config::Config;
 use vsmtp_rule_engine::rule_engine::RuleEngine;
@@ -58,6 +61,10 @@ pub fn start_runtime(
         std::net::TcpListener,
     ),
 ) -> anyhow::Result<()> {
+    <Queue as strum::IntoEnumIterator>::iter()
+        .map(|q| vsmtp_common::queue_path!(create_if_missing => &config.server.queues.dirpath, q))
+        .collect::<std::io::Result<Vec<_>>>()?;
+
     let (main_runtime_sender, mut main_runtime_receiver) =
         tokio::sync::mpsc::channel::<anyhow::Result<()>>(
             config.server.queues.delivery.channel_size,


### PR DESCRIPTION
* `vqueue` does not create a queue if missing, and print `<MISSING>` for `show` command
* adding padding for long domains name
* remove `Queue::to_path` and use a macro `queue_path!`
* in vSMTP create the queues at initialization (after privileges drop) , and not after booting anymore