### PR TITLE
feat(mbox/maildir): group_local variable

### DIFF
--- a/vsmtp-config/src/builder/validate.rs
+++ b/vsmtp-config/src/builder/validate.rs
@@ -46,6 +46,7 @@ impl Builder<WantsValidate> {
                 system: ConfigServerSystem {
                     user: srv_syst.user,
                     group: srv_syst.group,
+                    group_local: srv_syst.group_local,
                     thread_pool: ConfigServerSystemThreadPool {
                         receiver: srv_syst.thread_pool_receiver,
                         processing: srv_syst.thread_pool_processing,

--- a/vsmtp-config/src/builder/wants.rs
+++ b/vsmtp-config/src/builder/wants.rs
@@ -32,6 +32,7 @@ pub struct WantsServerInterfaces {
     pub(crate) parent: WantsServerSystem,
     pub(super) user: users::User,
     pub(super) group: users::Group,
+    pub(super) group_local: Option<users::Group>,
     pub(super) thread_pool_receiver: usize,
     pub(super) thread_pool_processing: usize,
     pub(super) thread_pool_delivery: usize,

--- a/vsmtp-config/src/builder/with.rs
+++ b/vsmtp-config/src/builder/with.rs
@@ -115,6 +115,7 @@ impl Builder<WantsServerSystem> {
         self.with_system(
             ConfigServerSystem::default_user(),
             ConfigServerSystem::default_group(),
+            None,
             ConfigServerSystemThreadPool::default_receiver(),
             ConfigServerSystemThreadPool::default_processing(),
             ConfigServerSystemThreadPool::default_delivery(),
@@ -132,6 +133,7 @@ impl Builder<WantsServerSystem> {
         self.with_system(
             ConfigServerSystem::default_user(),
             ConfigServerSystem::default_group(),
+            None,
             thread_pool_receiver,
             thread_pool_processing,
             thread_pool_delivery,
@@ -150,6 +152,7 @@ impl Builder<WantsServerSystem> {
         self.with_system_str(
             user,
             group,
+            None,
             ConfigServerSystemThreadPool::default_receiver(),
             ConfigServerSystemThreadPool::default_processing(),
             ConfigServerSystemThreadPool::default_delivery(),
@@ -162,6 +165,7 @@ impl Builder<WantsServerSystem> {
         self,
         user: users::User,
         group: users::Group,
+        group_local: Option<users::Group>,
         thread_pool_receiver: usize,
         thread_pool_processing: usize,
         thread_pool_delivery: usize,
@@ -171,6 +175,7 @@ impl Builder<WantsServerSystem> {
                 parent: self.state,
                 user,
                 group,
+                group_local,
                 thread_pool_receiver,
                 thread_pool_processing,
                 thread_pool_delivery,
@@ -186,6 +191,7 @@ impl Builder<WantsServerSystem> {
         self,
         user: &str,
         group: &str,
+        group_local: Option<&str>,
         thread_pool_receiver: usize,
         thread_pool_processing: usize,
         thread_pool_delivery: usize,
@@ -197,6 +203,14 @@ impl Builder<WantsServerSystem> {
                     .ok_or_else(|| anyhow::anyhow!("user not found: '{}'", user))?,
                 group: users::get_group_by_name(group)
                     .ok_or_else(|| anyhow::anyhow!("group not found: '{}'", group))?,
+                group_local: if let Some(group_local) = group_local {
+                    Some(
+                        users::get_group_by_name(group_local)
+                            .ok_or_else(|| anyhow::anyhow!("group not found: '{}'", group_local))?,
+                    )
+                } else {
+                    None
+                },
                 thread_pool_receiver,
                 thread_pool_processing,
                 thread_pool_delivery,

--- a/vsmtp-config/src/config.rs
+++ b/vsmtp-config/src/config.rs
@@ -82,6 +82,12 @@ pub struct ConfigServerSystem {
     )]
     pub group: users::Group,
     #[serde(default)]
+    #[serde(
+        serialize_with = "crate::parser::syst_group::opt_serialize",
+        deserialize_with = "crate::parser::syst_group::opt_deserialize"
+    )]
+    pub group_local: Option<users::Group>,
+    #[serde(default)]
     pub thread_pool: ConfigServerSystemThreadPool,
 }
 

--- a/vsmtp-config/src/default.rs
+++ b/vsmtp-config/src/default.rs
@@ -60,6 +60,7 @@ impl Default for ConfigServerSystem {
         Self {
             user: Self::default_user(),
             group: Self::default_group(),
+            group_local: None,
             thread_pool: ConfigServerSystemThreadPool::default(),
         }
     }


### PR DESCRIPTION
the user can now configure the group used to write emails locally.

```toml
[server.system]
# ...
group_local = "vsmtp"
```

this argument is optional, the current group is used if not set.