### PR TITLE
Add a flag '--timeout' on vsmtp

### DIFF
--- a/vsmtp-config/src/lib.rs
+++ b/vsmtp-config/src/lib.rs
@@ -74,6 +74,7 @@ pub use trust_dns_helper::build_resolvers;
 
 /// Re-exported dependencies
 pub mod re {
+    pub use humantime_serde::re::humantime;
     pub use log4rs;
     pub use rustls;
     // NOTE: this one should not be re-exported (because tests only)

--- a/vsmtp-server/src/lib.rs
+++ b/vsmtp-server/src/lib.rs
@@ -14,6 +14,7 @@
 mod tests;
 
 mod log_channels {
+    pub const SERVER: &str = "server::server";
     pub const AUTH: &str = "server::receiver::auth";
     pub const CONNECTION: &str = "server::receiver::connection";
     pub const TRANSACTION: &str = "server::receiver::transaction";

--- a/vsmtp-server/tests/stress/listen_and_serve_ignored_test.rs
+++ b/vsmtp-server/tests/stress/listen_and_serve_ignored_test.rs
@@ -91,7 +91,7 @@ async fn listen_and_serve() {
         RuleEngine::new(&config, &None).unwrap(),
     ));
 
-    let mut server = Server::new(
+    let server = Server::new(
         std::sync::Arc::new(config),
         sockets,
         rule_engine,

--- a/vsmtp/src/main.rs
+++ b/vsmtp/src/main.rs
@@ -111,7 +111,7 @@ fn try_main() -> anyhow::Result<()> {
         .map(log4rs::init_config)
         .context("Cannot initialize logs")??;
 
-    start_runtime(std::sync::Arc::new(config), sockets).map_err(|e| {
+    start_runtime(config, sockets, args.timeout.map(|t| t.0)).map_err(|e| {
         log::error!("vSMTP terminating error: '{e}'");
         e
     })


### PR DESCRIPTION
Add the following argument to `vsmtp` :
```sh
    -t, --timeout <TIMEOUT>    Make the server stop after a delay (human readable format)
```

Add a tests running the server for 1 seconds, initializing all the runtimes (and with a lot of side effect)