### PR TITLE
No vsl path behavior

### DIFF
--- a/vsmtp-config/src/builder/wants.rs
+++ b/vsmtp-config/src/builder/wants.rs
@@ -122,7 +122,7 @@ pub struct WantsAppVSL {
 ///
 pub struct WantsAppLogs {
     pub(crate) parent: WantsAppVSL,
-    pub(super) filepath: std::path::PathBuf,
+    pub(super) filepath: Option<std::path::PathBuf>,
 }
 
 ///

--- a/vsmtp-config/src/builder/with.rs
+++ b/vsmtp-config/src/builder/with.rs
@@ -28,11 +28,10 @@ use super::{
 };
 use crate::{
     config::{
-        ConfigApp, ConfigAppLogs, ConfigAppVSL, ConfigQueueDelivery, ConfigQueueWorking,
-        ConfigServer, ConfigServerDNS, ConfigServerInterfaces, ConfigServerLogs,
-        ConfigServerQueues, ConfigServerSMTP, ConfigServerSMTPError, ConfigServerSMTPTimeoutClient,
-        ConfigServerSystem, ConfigServerSystemThreadPool, ConfigServerTls, ConfigServerVirtual,
-        TlsSecurityLevel,
+        ConfigApp, ConfigAppLogs, ConfigQueueDelivery, ConfigQueueWorking, ConfigServer,
+        ConfigServerDNS, ConfigServerInterfaces, ConfigServerLogs, ConfigServerQueues,
+        ConfigServerSMTP, ConfigServerSMTPError, ConfigServerSMTPTimeoutClient, ConfigServerSystem,
+        ConfigServerSystemThreadPool, ConfigServerTls, ConfigServerVirtual, TlsSecurityLevel,
     },
     parser::{tls_certificate, tls_private_key},
     ConfigServerSMTPAuth, ResolverOptsWrapper, Service,
@@ -552,7 +551,12 @@ impl Builder<WantsAppVSL> {
     ///
     #[must_use]
     pub fn with_default_vsl_settings(self) -> Builder<WantsAppLogs> {
-        self.with_vsl(ConfigAppVSL::default_filepath())
+        Builder::<WantsAppLogs> {
+            state: WantsAppLogs {
+                parent: self.state,
+                filepath: None,
+            },
+        }
     }
 
     ///
@@ -561,7 +565,7 @@ impl Builder<WantsAppVSL> {
         Builder::<WantsAppLogs> {
             state: WantsAppLogs {
                 parent: self.state,
-                filepath: entry_point.into(),
+                filepath: Some(entry_point.into()),
             },
         }
     }

--- a/vsmtp-config/src/config.rs
+++ b/vsmtp-config/src/config.rs
@@ -420,10 +420,10 @@ pub struct ResolverOptsWrapper {
     pub num_concurrent_reqs: usize,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ConfigAppVSL {
-    pub filepath: std::path::PathBuf,
+    pub filepath: Option<std::path::PathBuf>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]

--- a/vsmtp-config/src/default.rs
+++ b/vsmtp-config/src/default.rs
@@ -442,20 +442,6 @@ impl ConfigApp {
     }
 }
 
-impl Default for ConfigAppVSL {
-    fn default() -> Self {
-        Self {
-            filepath: Self::default_filepath(),
-        }
-    }
-}
-
-impl ConfigAppVSL {
-    pub(crate) fn default_filepath() -> std::path::PathBuf {
-        "/etc/vsmtp/rules/main.vsl".into()
-    }
-}
-
 impl Default for ConfigAppLogs {
     fn default() -> Self {
         Self {

--- a/vsmtp-server/src/processes/delivery/deferred.rs
+++ b/vsmtp-server/src/processes/delivery/deferred.rs
@@ -141,7 +141,7 @@ mod tests {
     async fn basic() {
         let mut config = config::local_test();
         config.server.queues.dirpath = "./tmp".into();
-        config.app.vsl.filepath = "./src/tests/empty_main.vsl".into();
+        config.app.vsl.filepath = Some("./src/tests/empty_main.vsl".into());
 
         let now = std::time::SystemTime::now();
 

--- a/vsmtp-server/src/runtime.rs
+++ b/vsmtp-server/src/runtime.rs
@@ -101,7 +101,7 @@ pub fn start_runtime(
 
     let rule_engine = std::sync::Arc::new(std::sync::RwLock::new(RuleEngine::new(
         &config,
-        &Some(config.app.vsl.filepath.clone()),
+        &config.app.vsl.filepath.clone(),
     )?));
 
     let config_arc = std::sync::Arc::new(config);

--- a/vsmtp-test/src/receiver.rs
+++ b/vsmtp-test/src/receiver.rs
@@ -119,7 +119,7 @@ where
     );
 
     let rule_engine = std::sync::Arc::new(std::sync::RwLock::new(
-        RuleEngine::new(&config, &Some(config.app.vsl.filepath.clone()))
+        RuleEngine::new(&config, &config.app.vsl.filepath.clone())
             .context("failed to initialize the engine")
             .unwrap(),
     ));

--- a/vsmtp-test/src/tests/auth/all_mechanism.rs
+++ b/vsmtp-test/src/tests/auth/all_mechanism.rs
@@ -47,11 +47,8 @@ async fn test_auth(
         let (client_stream, client_addr) = socket_server.accept().await.unwrap();
 
         let rule_engine = std::sync::Arc::new(std::sync::RwLock::new(
-            RuleEngine::new(
-                &server_config,
-                &Some(server_config.app.vsl.filepath.clone()),
-            )
-            .expect("failed to initialize the engine"),
+            RuleEngine::new(&server_config, &server_config.app.vsl.filepath.clone())
+                .expect("failed to initialize the engine"),
         ));
 
         Server::run_session(

--- a/vsmtp-test/src/tests/custom_codes.rs
+++ b/vsmtp-test/src/tests/custom_codes.rs
@@ -23,7 +23,7 @@ use vsmtp_server::re::tokio;
 async fn info_message() {
     let mut config = config::local_test();
     config.app.vsl.filepath =
-        std::path::PathBuf::from_str("./src/tests/custom_codes_info.vsl").unwrap();
+        Some(std::path::PathBuf::from_str("./src/tests/custom_codes_info.vsl").unwrap());
 
     assert!(test_receiver! {
         with_config => config,
@@ -60,7 +60,7 @@ async fn info_message() {
 async fn deny_message() {
     let mut config = config::local_test();
     config.app.vsl.filepath =
-        std::path::PathBuf::from_str("./src/tests/custom_codes_deny.vsl").unwrap();
+        Some(std::path::PathBuf::from_str("./src/tests/custom_codes_deny.vsl").unwrap());
 
     assert!(test_receiver! {
         with_config => config.clone(),

--- a/vsmtp-test/src/tests/tls/mod.rs
+++ b/vsmtp-test/src/tests/tls/mod.rs
@@ -99,10 +99,7 @@ async fn test_starttls(
             None,
             std::sync::Arc::new(std::sync::RwLock::new(
                 anyhow::Context::context(
-                    RuleEngine::new(
-                        &server_config,
-                        &Some(server_config.app.vsl.filepath.clone()),
-                    ),
+                    RuleEngine::new(&server_config, &server_config.app.vsl.filepath.clone()),
                     "failed to initialize the engine",
                 )
                 .unwrap(),
@@ -235,11 +232,7 @@ async fn test_tls_tunneled(
             get_tls_config(&server_config),
             get_auth_config(&server_config),
             std::sync::Arc::new(std::sync::RwLock::new(
-                RuleEngine::new(
-                    &server_config,
-                    &Some(server_config.app.vsl.filepath.clone()),
-                )
-                .unwrap(),
+                RuleEngine::new(&server_config, &server_config.app.vsl.filepath.clone()).unwrap(),
             )),
             working_sender,
             delivery_sender,

--- a/vsmtp-test/src/tests/tls/tunneled.rs
+++ b/vsmtp-test/src/tests/tls/tunneled.rs
@@ -139,7 +139,7 @@ async fn config_ill_formed() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 3)]
 async fn sni() {
     let mut config = get_tls_config();
-    config.app.vsl.filepath = "./src/vsl/sni.vsl".into();
+    config.app.vsl.filepath = Some("./src/vsl/sni.vsl".into());
     config.server.tls.as_mut().unwrap().security_level = TlsSecurityLevel::Encrypt;
     config.server.r#virtual.insert(
         "second.testserver.com".to_string(),

--- a/vsmtp-test/src/tests/tls/tunneled_with_auth.rs
+++ b/vsmtp-test/src/tests/tls/tunneled_with_auth.rs
@@ -49,7 +49,7 @@ fn get_tls_auth_config() -> Config {
 #[tokio::test(flavor = "multi_thread", worker_threads = 3)]
 async fn simple() {
     let mut config = get_tls_auth_config();
-    config.app.vsl.filepath = "./src/tests/auth.vsl".into();
+    config.app.vsl.filepath = Some("./src/tests/auth.vsl".into());
 
     let (client, server) = test_tls_tunneled(
         "testserver.com",


### PR DESCRIPTION
If no vsl filepath is set in the toml config, the rule engine will emit a warning & deny everything by default.