### PR TITLE
App Invalid Paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2003,6 +2003,7 @@ dependencies = [
  "vsmtp-common",
  "vsmtp-config",
  "vsmtp-mail-parser",
+ "vsmtp-test",
  "wait-timeout",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2032,7 +2032,9 @@ name = "vsmtp-test"
 version = "1.0.0"
 dependencies = [
  "async-trait",
+ "fastrand",
  "lettre",
+ "log4rs",
  "pretty_assertions",
  "tokio-rustls",
  "vsmtp-common",

--- a/examples/config/antivirus.toml
+++ b/examples/config/antivirus.toml
@@ -4,4 +4,4 @@ version_requirement = "=1.0.0"
 type = "system"
 
 [app.vsl]
-filepath = "./examples/config/antivirus/main.vsl"
+filepath = "examples/config/antivirus/main.vsl"

--- a/examples/config/tls.toml
+++ b/examples/config/tls.toml
@@ -8,8 +8,8 @@ security_level = "May"
 preempt_cipherlist = false
 handshake_timeout = "200ms"
 protocol_version = "TLSv1.3"
-certificate = "../../../examples/config/tls/certificate.crt"
-private_key = "../../../examples/config/tls/private_key.key"
+certificate = "examples/config/tls/certificate.crt"
+private_key = "examples/config/tls/private_key.key"
 
 [server.virtual."testserver1.com"]
 
@@ -18,13 +18,13 @@ type = "system"
 
 [server.virtual."testserver3.com".tls]
 protocol_version = "TLSv1.3"
-certificate = "../../../examples/config/tls/certificate.crt"
-private_key = "../../../examples/config/tls/private_key.key"
+certificate = "examples/config/tls/certificate.crt"
+private_key = "examples/config/tls/private_key.key"
 
 [server.virtual."testserver4.com".tls]
 protocol_version = "TLSv1.3"
-certificate = "../../../examples/config/tls/certificate.crt"
-private_key = "../../../examples/config/tls/private_key.key"
+certificate = "examples/config/tls/certificate.crt"
+private_key = "examples/config/tls/private_key.key"
 
 [server.virtual."testserver4.com".dns]
 type = "google"

--- a/src/vsmtp/vsmtp-config/src/builder/validate.rs
+++ b/src/vsmtp/vsmtp-config/src/builder/validate.rs
@@ -147,7 +147,21 @@ impl Config {
             config.server.system.thread_pool.processing != 0
                 && config.server.system.thread_pool.receiver != 0
                 && config.server.system.thread_pool.delivery != 0,
-            "Worker threads cannot be set to 0"
+            "Worker threads cannot be set to 0."
+        );
+
+        if let Some(filepath) = config.app.vsl.filepath.as_ref() {
+            anyhow::ensure!(
+                filepath.exists(),
+                "rules entrypoint at {} does not exists.",
+                filepath.display()
+            );
+        }
+
+        anyhow::ensure!(
+            config.app.dirpath.exists(),
+            "application directory at {} does not exists.",
+            config.app.dirpath.display()
         );
 
         {

--- a/src/vsmtp/vsmtp-config/src/config.rs
+++ b/src/vsmtp/vsmtp-config/src/config.rs
@@ -420,7 +420,7 @@ pub struct ResolverOptsWrapper {
     pub num_concurrent_reqs: usize,
 }
 
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[derive(Debug, Default, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ConfigAppVSL {
     pub filepath: Option<std::path::PathBuf>,

--- a/src/vsmtp/vsmtp-config/src/tests/root_example/antivirus.rs
+++ b/src/vsmtp/vsmtp-config/src/tests/root_example/antivirus.rs
@@ -19,8 +19,10 @@ use crate::Config;
 #[test]
 fn parse() {
     let _ctx = vsmtp_test::TestContext::new().unwrap();
-
     let toml = include_str!("../../../../../../examples/config/antivirus.toml");
+
+    println!("current dir: {:?}", std::env::current_dir());
+
     pretty_assertions::assert_eq!(
         Config::from_toml(toml).unwrap(),
         Config::builder()

--- a/src/vsmtp/vsmtp-config/src/tests/root_example/antivirus.rs
+++ b/src/vsmtp/vsmtp-config/src/tests/root_example/antivirus.rs
@@ -18,6 +18,8 @@ use crate::Config;
 
 #[test]
 fn parse() {
+    let _ctx = vsmtp_test::TestContext::new().unwrap();
+
     let toml = include_str!("../../../../../../examples/config/antivirus.toml");
     pretty_assertions::assert_eq!(
         Config::from_toml(toml).unwrap(),
@@ -35,7 +37,7 @@ fn parse() {
             .with_default_smtp_codes()
             .without_auth()
             .with_default_app()
-            .with_vsl("./examples/config/antivirus/main.vsl")
+            .with_vsl("examples/config/antivirus/main.vsl")
             .with_default_app_logs()
             .with_system_dns()
             .without_virtual_entries()

--- a/src/vsmtp/vsmtp-config/src/tests/root_example/tls.rs
+++ b/src/vsmtp/vsmtp-config/src/tests/root_example/tls.rs
@@ -18,6 +18,7 @@ use crate::{builder::VirtualEntry, Config, ConfigServerDNS, ResolverOptsWrapper}
 
 #[test]
 fn parse() {
+    let _test = vsmtp_test::TestContext::new().unwrap();
     let toml = include_str!("../../../../../../examples/config/tls.toml");
 
     pretty_assertions::assert_eq!(
@@ -31,8 +32,8 @@ fn parse() {
             .with_default_logs_settings()
             .with_default_delivery()
             .with_safe_tls_config(
-                "../../../examples/config/tls/certificate.crt",
-                "../../../examples/config/tls/private_key.key"
+                "examples/config/tls/certificate.crt",
+                "examples/config/tls/private_key.key"
             )
             .unwrap()
             .with_default_smtp_options()
@@ -57,16 +58,16 @@ fn parse() {
                 VirtualEntry {
                     domain: "testserver3.com".to_string(),
                     tls: Some((
-                        "../../../examples/config/tls/certificate.crt".to_string(),
-                        "../../../examples/config/tls/private_key.key".to_string()
+                        "examples/config/tls/certificate.crt".to_string(),
+                        "examples/config/tls/private_key.key".to_string()
                     )),
                     dns: None,
                 },
                 VirtualEntry {
                     domain: "testserver4.com".to_string(),
                     tls: Some((
-                        "../../../examples/config/tls/certificate.crt".to_string(),
-                        "../../../examples/config/tls/private_key.key".to_string()
+                        "examples/config/tls/certificate.crt".to_string(),
+                        "examples/config/tls/private_key.key".to_string()
                     )),
                     dns: Some(ConfigServerDNS::Google {
                         options: ResolverOptsWrapper::default()

--- a/src/vsmtp/vsmtp-rule-engine/Cargo.toml
+++ b/src/vsmtp/vsmtp-rule-engine/Cargo.toml
@@ -59,3 +59,4 @@ wait-timeout = "0.2.0"
 
 [dev-dependencies]
 vsmtp-mail-parser = { path = "../vsmtp-mail-parser" }
+vsmtp-test = { path = "../vsmtp-test" }

--- a/src/vsmtp/vsmtp-rule-engine/src/tests/actions.rs
+++ b/src/vsmtp/vsmtp-rule-engine/src/tests/actions.rs
@@ -30,12 +30,13 @@ use vsmtp_common::{
     transfer::Transfer,
 };
 use vsmtp_config::ConfigServerVirtual;
+use vsmtp_test::vsl_example;
 
 #[test]
 fn test_logs() {
     let re = RuleEngine::new(
         &vsmtp_config::Config::default(),
-        &Some(root_example!["actions/logs.vsl"]),
+        &Some(vsl_example!["actions/logs.vsl"]),
     )
     .unwrap();
     let (mut state, _) = get_default_state("./tmp/app");
@@ -49,7 +50,7 @@ fn test_logs() {
 fn test_users() {
     let re = RuleEngine::new(
         &vsmtp_config::Config::default(),
-        &Some(root_example!["actions/utils.vsl"]),
+        &Some(vsl_example!["actions/utils.vsl"]),
     )
     .unwrap();
     let (mut state, _) = get_default_state("./tmp/app");
@@ -62,8 +63,8 @@ fn test_users() {
 
 #[test]
 fn test_send_mail() {
-    let (mut state, config) = get_default_state(format!("{}", root_example!["actions"].display()));
-    let re = RuleEngine::new(&config, &Some(root_example!["actions/send_mail.vsl"])).unwrap();
+    let (mut state, config) = get_default_state(format!("{}", vsl_example!["actions"].display()));
+    let re = RuleEngine::new(&config, &Some(vsl_example!["actions/send_mail.vsl"])).unwrap();
 
     // TODO: add test to send a valid email.
     assert_eq!(re.run_when(&mut state, &StateSMTP::Connect), Status::Accept);
@@ -73,7 +74,7 @@ fn test_send_mail() {
 fn test_context_write() {
     let re = RuleEngine::new(
         &vsmtp_config::Config::default(),
-        &Some(root_example!["actions/write.vsl"]),
+        &Some(vsl_example!["actions/write.vsl"]),
     )
     .unwrap();
     let (mut state, _) = get_default_state("./tmp/app");
@@ -119,7 +120,7 @@ This is a raw email.
 fn test_context_dump() {
     let re = RuleEngine::new(
         &vsmtp_config::Config::default(),
-        &Some(root_example!["actions/dump.vsl"]),
+        &Some(vsl_example!["actions/dump.vsl"]),
     )
     .unwrap();
     let (mut state, _) = get_default_state("./tmp/app");
@@ -156,7 +157,7 @@ fn test_context_dump() {
 fn test_quarantine() {
     let re = RuleEngine::new(
         &vsmtp_config::Config::default(),
-        &Some(root_example!["actions/quarantine.vsl"]),
+        &Some(vsl_example!["actions/quarantine.vsl"]),
     )
     .unwrap();
     let (mut state, _) = get_default_state("./tmp/app");
@@ -208,7 +209,7 @@ fn test_quarantine() {
 fn test_forward() {
     let re = RuleEngine::new(
         &vsmtp_config::Config::default(),
-        &Some(root_example!["actions/forward.vsl"]),
+        &Some(vsl_example!["actions/forward.vsl"]),
     )
     .unwrap();
     let (mut state, _) = get_default_state("./tmp/app");
@@ -269,7 +270,7 @@ fn test_forward() {
 fn test_forward_all() {
     let re = RuleEngine::new(
         &vsmtp_config::Config::default(),
-        &Some(root_example!["actions/forward_all.vsl"]),
+        &Some(vsl_example!["actions/forward_all.vsl"]),
     )
     .unwrap();
     let (mut state, _) = get_default_state("./tmp/app");
@@ -405,7 +406,7 @@ fn test_forward_all() {
 fn test_hostname() {
     let re = RuleEngine::new(
         &vsmtp_config::Config::default(),
-        &Some(root_example!["actions/utils.vsl"]),
+        &Some(vsl_example!["actions/utils.vsl"]),
     )
     .unwrap();
     let (mut state, _) = get_default_state("./tmp/app");
@@ -416,7 +417,7 @@ fn test_hostname() {
 #[test]
 fn test_in_domain_and_server_name() {
     let (mut state, config) = get_default_state("./tmp/app");
-    let re = RuleEngine::new(&config, &Some(root_example!["actions/utils.vsl"])).unwrap();
+    let re = RuleEngine::new(&config, &Some(vsl_example!["actions/utils.vsl"])).unwrap();
 
     assert_eq!(re.run_when(&mut state, &StateSMTP::Connect), Status::Accept);
 }
@@ -430,7 +431,7 @@ fn test_in_domain_and_server_name_sni() {
         ("green.com".to_string(), ConfigServerVirtual::new()),
     ]);
 
-    let re = RuleEngine::new(&config, &Some(root_example!["actions/utils.vsl"])).unwrap();
+    let re = RuleEngine::new(&config, &Some(vsl_example!["actions/utils.vsl"])).unwrap();
     let mut state = RuleState::new(&config, &re);
 
     assert_eq!(re.run_when(&mut state, &StateSMTP::PreQ), Status::Accept);

--- a/src/vsmtp/vsmtp-rule-engine/src/tests/engine/mod.rs
+++ b/src/vsmtp/vsmtp-rule-engine/src/tests/engine/mod.rs
@@ -80,7 +80,7 @@ fn test_rule_state() {
         .with_default_smtp_codes()
         .without_auth()
         .with_default_app()
-        .with_vsl("./src/tests/empty_main.vsl")
+        .with_default_vsl_settings()
         .with_default_app_logs()
         .with_system_dns()
         .without_virtual_entries()

--- a/src/vsmtp/vsmtp-rule-engine/src/tests/integrations.rs
+++ b/src/vsmtp/vsmtp-rule-engine/src/tests/integrations.rs
@@ -20,15 +20,16 @@
 //       to locate vsl's example scripts.
 
 use vsmtp_common::{state::StateSMTP, status::Status};
+use vsmtp_test::vsl_example;
 
 use crate::{rule_engine::RuleEngine, rule_state::RuleState, tests::helpers::get_default_config};
 
 #[test]
 fn test_greylist() {
-    std::fs::File::create(root_example!["greylist/greylist.csv"]).unwrap();
+    std::fs::File::create(vsl_example!["greylist/greylist.csv"]).unwrap();
 
     let config = get_default_config("./tmp/app");
-    let re = RuleEngine::new(&config, &Some(root_example!["greylist/main.vsl"])).unwrap();
+    let re = RuleEngine::new(&config, &Some(vsl_example!["greylist/main.vsl"])).unwrap();
     let mut state = RuleState::new(&config, &re);
 
     assert_eq!(
@@ -36,7 +37,7 @@ fn test_greylist() {
         Status::Deny(None)
     );
 
-    let re = RuleEngine::new(&config, &Some(root_example!["greylist/main.vsl"])).unwrap();
+    let re = RuleEngine::new(&config, &Some(vsl_example!["greylist/main.vsl"])).unwrap();
     let mut state = RuleState::new(&config, &re);
 
     assert_eq!(
@@ -44,5 +45,5 @@ fn test_greylist() {
         Status::Accept
     );
 
-    std::fs::remove_file(root_example!["greylist/greylist.csv"]).unwrap();
+    std::fs::remove_file(vsl_example!["greylist/greylist.csv"]).unwrap();
 }

--- a/src/vsmtp/vsmtp-rule-engine/src/tests/mod.rs
+++ b/src/vsmtp/vsmtp-rule-engine/src/tests/mod.rs
@@ -27,21 +27,6 @@ macro_rules! rules_path {
     ];
 }
 
-macro_rules! root_example {
-    ( $( $x:expr ),* ) => {
-        std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
-            .parent()
-            .unwrap()
-            .parent()
-            .unwrap()
-            .parent()
-            .unwrap()
-            .join("examples/vsl")
-            .join(std::path::PathBuf::from_iter([ $( $x, )* ]))
-            .to_path_buf()
-    };
-}
-
 mod actions;
 mod email;
 mod engine;
@@ -70,7 +55,7 @@ pub mod helpers {
             .with_default_smtp_codes()
             .without_auth()
             .with_app_at_location(dirpath)
-            .with_vsl("./src/tests/empty_main.vsl")
+            .with_default_vsl_settings()
             .with_default_app_logs()
             .with_system_dns()
             .without_virtual_entries()
@@ -95,7 +80,7 @@ pub mod helpers {
             .with_default_smtp_codes()
             .without_auth()
             .with_app_at_location(dirpath)
-            .with_vsl("./src/tests/empty_main.vsl")
+            .with_default_vsl_settings()
             .with_default_app_logs()
             .with_system_dns()
             .without_virtual_entries()

--- a/src/vsmtp/vsmtp-rule-engine/src/tests/rules.rs
+++ b/src/vsmtp/vsmtp-rule-engine/src/tests/rules.rs
@@ -17,12 +17,13 @@
 use crate::{rule_engine::RuleEngine, tests::helpers::get_default_state};
 use vsmtp_common::{addr, mail_context::Body, state::StateSMTP, status::Status, MailParser};
 use vsmtp_mail_parser::MailMimeParser;
+use vsmtp_test::vsl_example;
 
 #[test]
 fn test_connect_rules() {
     let re = RuleEngine::new(
         &vsmtp_config::Config::default(),
-        &Some(root_example!["rules/connect.vsl"]),
+        &Some(vsl_example!["rules/connect.vsl"]),
     )
     .unwrap();
     let (mut state, _) = get_default_state("./tmp/app");
@@ -42,7 +43,7 @@ fn test_connect_rules() {
 fn test_helo_rules() {
     let re = RuleEngine::new(
         &vsmtp_config::Config::default(),
-        &Some(root_example!["rules/helo.vsl"]),
+        &Some(vsl_example!["rules/helo.vsl"]),
     )
     .unwrap();
     let (mut state, _) = get_default_state("./tmp/app");
@@ -56,7 +57,7 @@ fn test_helo_rules() {
 fn test_mail_from_rules() {
     let re = RuleEngine::new(
         &vsmtp_config::Config::default(),
-        &Some(root_example!["rules/mail.vsl"]),
+        &Some(vsl_example!["rules/mail.vsl"]),
     )
     .unwrap();
 
@@ -93,7 +94,7 @@ This is a reply to your hello."#,
 fn test_rcpt_rules() {
     let re = RuleEngine::new(
         &vsmtp_config::Config::default(),
-        &Some(root_example!["rules/rcpt.vsl"]),
+        &Some(vsl_example!["rules/rcpt.vsl"]),
     )
     .unwrap();
 

--- a/src/vsmtp/vsmtp-rule-engine/src/tests/types/mod.rs
+++ b/src/vsmtp/vsmtp-rule-engine/src/tests/types/mod.rs
@@ -17,6 +17,7 @@
 use crate::{rule_engine::RuleEngine, rule_state::RuleState, tests::helpers::get_default_state};
 use vsmtp_common::{addr, mail_context::Body, state::StateSMTP, status::Status};
 use vsmtp_config::{builder::VirtualEntry, Config, ConfigServerDNS};
+use vsmtp_test::root_example;
 
 #[test]
 fn test_status() {
@@ -97,7 +98,7 @@ fn test_services() {
         .with_default_smtp_codes()
         .without_auth()
         .with_app_at_location("./tmp/app")
-        .with_vsl("./tmp/nothing")
+        .with_default_vsl_settings()
         .with_default_app_logs()
         .with_system_dns()
         .without_virtual_entries()
@@ -130,17 +131,17 @@ fn test_config_display() {
         .with_default_smtp_codes()
         .without_auth()
         .with_app_at_location("./tmp/app")
-        .with_vsl("./tmp/nothing")
+        .with_default_vsl_settings()
         .with_default_app_logs()
         .with_system_dns()
         .with_virtual_entries(&[VirtualEntry {
             domain: "domain@example.com".to_string(),
             tls: Some((
-                root_example!["../config/tls/certificate.crt"]
+                root_example!["config/tls/certificate.crt"]
                     .to_str()
                     .unwrap()
                     .to_string(),
-                root_example!["../config/tls/private_key.key"]
+                root_example!["config/tls/private_key.key"]
                     .to_str()
                     .unwrap()
                     .to_string(),

--- a/src/vsmtp/vsmtp-rule-engine/src/tests/types/objects/main.vsl
+++ b/src/vsmtp/vsmtp-rule-engine/src/tests/types/objects/main.vsl
@@ -57,7 +57,7 @@ import "vars" as vars;
             && toml::server.virtual["domain@example.com"].tls.protocol_version == ["TLSv1.3"]
 
             && toml::app.dirpath == "./tmp/app"
-            && toml::app.vsl.filepath == "./tmp/nothing" {
+            && toml::app.logs.filepath == "/var/log/vsmtp/app.log" {
                 next()
             } else {
                 deny()

--- a/src/vsmtp/vsmtp-test/Cargo.toml
+++ b/src/vsmtp/vsmtp-test/Cargo.toml
@@ -25,11 +25,15 @@ async-trait = "0.1.53"
 
 pretty_assertions = "1.2.1"
 
+fastrand = "1.7.0"
+
 lettre = { version = "0.10.0-rc.6", default-features = false, features = [
     "smtp-transport",
     "builder",
     "tokio1-rustls-tls",
     "tracing",
 ] }
-
+log4rs = { version = "1.1.1", default-features = false, features = [
+    "console_appender",
+] }
 tokio-rustls = "0.23.4"

--- a/src/vsmtp/vsmtp-test/src/lib.rs
+++ b/src/vsmtp/vsmtp-test/src/lib.rs
@@ -22,6 +22,40 @@ pub mod get_tls_file;
 #[cfg(test)]
 mod tests;
 
+/// get the example folder at the workspace root.
+#[macro_export]
+macro_rules! root_example {
+    ( $( $x:expr ),* ) => {
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .unwrap()
+            .parent()
+            .unwrap()
+            .parent()
+            .unwrap()
+            .join("examples")
+            .join(std::path::PathBuf::from_iter([ $( $x, )* ]))
+            .to_path_buf()
+    };
+}
+
+/// get vsl examples at the workspace root.
+#[macro_export]
+macro_rules! vsl_example {
+    ( $( $x:expr ),* ) => {
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .unwrap()
+            .parent()
+            .unwrap()
+            .parent()
+            .unwrap()
+            .join("examples/vsl")
+            .join(std::path::PathBuf::from_iter([ $( $x, )* ]))
+            .to_path_buf()
+    };
+}
+
 const TESTS_ROOT_WORKSPACE: &str = "./tests_root_workspace";
 
 /// holds metadata to run integration tests.

--- a/src/vsmtp/vsmtp-test/src/lib.rs
+++ b/src/vsmtp/vsmtp-test/src/lib.rs
@@ -21,3 +21,101 @@ pub mod get_tls_file;
 
 #[cfg(test)]
 mod tests;
+
+const TESTS_ROOT_WORKSPACE: &str = "./tests_root_workspace";
+
+/// holds metadata to run integration tests.
+/// tests must be under `src/vsmtp/`
+pub struct TestContext {
+    /// the path to the workspace of the test. fs resources can be written
+    /// in this path.
+    workspace: std::path::PathBuf,
+}
+
+static INIT_LOGS: std::sync::Once = std::sync::Once::new();
+
+impl TestContext {
+    /// create a new test context.
+    /// this sets the current directory to the workspace root.
+    /// it also initializes logs if needed and creates a new workspace
+    /// to work with.
+    ///
+    /// # Errors
+    /// * failed to create a test workspace.
+    ///
+    /// # Panics
+    /// * Could not set the current dir to the root of the workspace.
+    pub fn new() -> std::io::Result<Self> {
+        INIT_LOGS.call_once(|| {
+            std::env::set_current_dir("../../../").unwrap();
+            initialize_tests_logs();
+        });
+
+        Ok(Self {
+            workspace: get_test_workspace()?,
+        })
+    }
+}
+
+impl Drop for TestContext {
+    fn drop(&mut self) {
+        std::fs::remove_dir_all(&self.workspace).unwrap();
+    }
+}
+
+/// create a workspace to make integration tests.
+/// the path returned is the path to the created workspace.
+/// the generated folder will be removed on test teardown.
+///
+/// # Errors
+///
+/// * failed to create a test workspace.
+fn get_test_workspace() -> std::io::Result<std::path::PathBuf> {
+    let path = std::path::PathBuf::from_iter([
+        initialize_tests_root_workspace(),
+        &std::iter::repeat_with(fastrand::alphanumeric)
+            .take(20)
+            .collect::<String>(),
+    ]);
+
+    std::fs::create_dir(&path)?;
+
+    Ok(path)
+}
+
+/// initializes logs using the console appender from log4rs.
+fn initialize_tests_logs() {
+    use log4rs::{append, config, encode, Config};
+    use vsmtp_common::re::log::LevelFilter;
+
+    let config = Config::builder()
+        .appender(
+            config::Appender::builder().build(
+                "stdout",
+                Box::new(
+                    append::console::ConsoleAppender::builder()
+                        .encoder(Box::new(encode::pattern::PatternEncoder::new(
+                            "{d(%Y-%m-%d %H:%M:%S%.f)} {h({l:<5} [{I}])} {t:<30} $ {m}{n}",
+                        )))
+                        .build(),
+                ),
+            ),
+        )
+        .build(
+            config::Root::builder()
+                .appender("stdout")
+                .build(LevelFilter::Warn),
+        )
+        .unwrap();
+
+    log4rs::init_config(config).unwrap();
+}
+
+/// create the folder that will hold all tests workspaces if needed.
+fn initialize_tests_root_workspace() -> &'static str {
+    if !std::path::Path::new(TESTS_ROOT_WORKSPACE).exists() {
+        std::fs::create_dir_all(TESTS_ROOT_WORKSPACE).unwrap();
+    }
+
+    TESTS_ROOT_WORKSPACE
+}


### PR DESCRIPTION
- Vsl entry point script & app directory are checked once the configuration is loaded.
- moved macros `root_example` & `vsl_example` to the `vsmtp-test` crate.
- add a `TextContext` struct available in `vsmtp-test` that:
  - initialize logs for tests.
  - set the working directory to the root of workspaces.
  - create a 'workspace' directory to dump files during tests & clean them up automatically when the struct goes out of scope.