### PR TITLE
Empty list of MX records

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,7 @@
     "cSpell.words": [
         "alpn",
         "appender",
+        "ascii",
         "authid",
         "authpass",
         "BITMIME",


### PR DESCRIPTION
The delivery method now uses the AAAA record of the targeted server when receiving an empty list of MX records, conforming to [rfc's 5321 section 5.1](https://www.rfc-editor.org/rfc/rfc5321#section-5.1)