### PR TITLE
Forward using socket address

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ flamegraph.svg
 perf.data
 perf.data.old
 stacks.folded
+
+*~*
+*#*

--- a/examples/vsl/actions/forward.vsl
+++ b/examples/vsl/actions/forward.vsl
@@ -8,6 +8,7 @@
             add_rcpt("object.ip4@example.com");
             add_rcpt("object.ip6@example.com");
             add_rcpt("object.fqdn@example.com");
+	    add_rcpt("socket@example.com");
         }
     ],
 
@@ -18,13 +19,14 @@
             object forward_ip6 ip6 = "::1";
             object forward_fqdn fqdn = "test.eu";
 
-            forward("fqdn@example.com", "localhost");
+	    forward("fqdn@example.com", "localhost");
             forward("ip4@example.com", "127.0.0.1");
             forward("ip6@example.com", "::1");
             forward("object.str@example.com", forward_str);
             forward("object.ip4@example.com", forward_ip4);
             forward("object.ip6@example.com", forward_ip6);
             forward("object.fqdn@example.com", forward_fqdn);
+	    forward("socket@example.com", "127.0.0.1:25");
         },
     ]
 }

--- a/src/vsmtp/vsmtp-common/src/transfer.rs
+++ b/src/vsmtp/vsmtp-common/src/transfer.rs
@@ -43,6 +43,8 @@ pub enum ForwardTarget {
     Domain(String),
     /// the target is an ip address, a domaine resolution needs to be made.
     Ip(std::net::IpAddr),
+    /// the target is an ip address with an associated port.
+    Socket(std::net::SocketAddr),
 }
 
 /// the delivery method / protocol used for a specific recipient.

--- a/src/vsmtp/vsmtp-rule-engine/src/tests/actions.rs
+++ b/src/vsmtp/vsmtp-rule-engine/src/tests/actions.rs
@@ -271,6 +271,11 @@ fn test_forward() {
         rcpt[6].transfer_method,
         Transfer::Forward(ForwardTarget::Domain("test.eu".to_string()))
     );
+    assert_eq!(rcpt[7].address.full(), "socket@example.com");
+    assert_eq!(
+        rcpt[7].transfer_method,
+        Transfer::Forward(ForwardTarget::Socket("127.0.0.1:25".parse().unwrap()))
+    );
 }
 
 #[test]

--- a/src/vsmtp/vsmtp-server/src/delivery/mod.rs
+++ b/src/vsmtp/vsmtp-server/src/delivery/mod.rs
@@ -129,7 +129,9 @@ async fn send_email(
                     ForwardTarget::Domain(domain) => resolvers
                         .get(domain)
                         .unwrap_or_else(|| resolvers.get(&config.server.domain).unwrap()),
-                    ForwardTarget::Ip(_) => resolvers.get(&config.server.domain).unwrap(),
+                    ForwardTarget::Ip(_) | ForwardTarget::Socket(_) => {
+                        resolvers.get(&config.server.domain).unwrap()
+                    }
                 },
             )),
             Transfer::Deliver => Box::new(deliver2::Deliver::new({


### PR DESCRIPTION
The forward action takes into account addresses with ports.

```rust
forward("john.doe@example.com", "127.0.0.1:25")
```