### PR TITLE
Logging fix

### DIFF
--- a/src/vsmtp/vsmtp-common/src/lib.rs
+++ b/src/vsmtp/vsmtp-common/src/lib.rs
@@ -39,6 +39,10 @@ pub const SUBMISSION_PORT: u16 = 587;
 /// Defined in [RFC8314](https://tools.ietf.org/html/rfc8314)
 pub const SUBMISSIONS_PORT: u16 = 465;
 
+mod log_channels {
+    pub const QUEUE: &str = "server::queue";
+}
+
 #[macro_use]
 mod r#type {
     #[macro_use]

--- a/src/vsmtp/vsmtp-common/src/queue.rs
+++ b/src/vsmtp/vsmtp-common/src/queue.rs
@@ -14,7 +14,10 @@
  * this program. If not, see https://www.gnu.org/licenses/.
  *
 */
-use crate::mail_context::{MailContext, MessageBody};
+use crate::{
+    log_channels,
+    mail_context::{MailContext, MessageBody},
+};
 use anyhow::Context;
 
 /// identifiers for all mail queues.
@@ -115,7 +118,10 @@ impl Queue {
 
         std::io::Write::write_all(&mut file, serde_json::to_string(ctx)?.as_bytes())?;
 
-        log::debug!("mail {message_id} successfully written to {self} queue");
+        log::debug!(
+            target: log_channels::QUEUE,
+            "mail {message_id} successfully written to {self} queue"
+        );
 
         Ok(())
     }

--- a/src/vsmtp/vsmtp-config/src/log4rs_helper.rs
+++ b/src/vsmtp/vsmtp-config/src/log4rs_helper.rs
@@ -15,6 +15,7 @@
  *
 */
 use crate::{log_channel, Config};
+use log4rs::append::rolling_file::RollingFileAppender;
 use vsmtp_common::re::{anyhow, log};
 
 fn init_rolling_log(
@@ -25,10 +26,7 @@ fn init_rolling_log(
 ) -> anyhow::Result<log4rs::append::rolling_file::RollingFileAppender> {
     use anyhow::Context;
     use log4rs::{
-        append::rolling_file::{
-            policy::compound::{roll, trigger, CompoundPolicy},
-            RollingFileAppender,
-        },
+        append::rolling_file::policy::compound::{roll, trigger, CompoundPolicy},
         encode,
     };
 
@@ -57,24 +55,24 @@ fn init_rolling_log(
 pub fn get_log4rs_config(config: &Config, no_daemon: bool) -> anyhow::Result<log4rs::Config> {
     use log4rs::{append, config, encode, Config};
 
-    let server = init_rolling_log(
+    let server: RollingFileAppender = init_rolling_log(
         &config.server.logs.format,
         &config.server.logs.filepath,
         config.server.logs.size_limit,
         config.server.logs.archive_count,
     )?;
-    let app = init_rolling_log(
+    let app: RollingFileAppender = init_rolling_log(
         &config.app.logs.format,
         &config.app.logs.filepath,
         config.app.logs.size_limit,
         config.app.logs.archive_count,
     )?;
 
-    let mut builder = Config::builder();
-    let mut root = config::Root::builder();
+    let mut log_builder = Config::builder();
+    let mut log_root_builder = config::Root::builder();
 
     if no_daemon {
-        builder = builder.appender(
+        log_builder = log_builder.appender(
             config::Appender::builder().build(
                 "stdout",
                 Box::new(
@@ -86,51 +84,50 @@ pub fn get_log4rs_config(config: &Config, no_daemon: bool) -> anyhow::Result<log
                 ),
             ),
         );
-        root = root.appender("stdout");
+
+        log_root_builder = log_root_builder.appender("stdout");
     }
 
-    builder
-        .appender(config::Appender::builder().build("server", Box::new(server)))
-        .appender(config::Appender::builder().build("app", Box::new(app)))
+    log_builder
+        .appender(config::Appender::builder().build(log_channel::DEFAULT, Box::new(server)))
+        .appender(config::Appender::builder().build(log_channel::APP, Box::new(app)))
         .loggers(config.server.logs.level.iter().filter_map(|(name, level)| {
             // adding all loggers under the "server" logger to simulate a root logger.
-            if name == "default" {
-                None
-            } else {
-                Some(config::Logger::builder().build(format!("server::{name}"), *level))
+            match name.as_str() {
+                log_channel::DEFAULT | "root" => None,
+                _ => Some(
+                    config::Logger::builder()
+                        .build(format!("{}::{}", log_channel::DEFAULT, name), *level),
+                ),
             }
         }))
         .logger(
             config::Logger::builder()
                 .appender("app")
-                .additive(false)
                 .build(log_channel::APP, config.app.logs.level),
         )
         // vSMTP's "root" logger under the name "default", all sub loggers inherit from this one.
         .logger(
-            config::Logger::builder()
-                .appender("server")
-                .additive(true)
-                .build(
-                    log_channel::DEFAULT,
-                    *config
-                        .server
-                        .logs
-                        .level
-                        .get("default")
-                        .unwrap_or(&log::LevelFilter::Warn),
-                ),
+            config::Logger::builder().appender("server").build(
+                log_channel::DEFAULT,
+                *config
+                    .server
+                    .logs
+                    .level
+                    .get(log_channel::DEFAULT)
+                    .unwrap_or(&log::LevelFilter::Warn),
+            ),
         )
         .build(
             // true "root" logger, enabling it set logs for vSMTP's dependencies.
             // the user doesn't need to set this 99% of the time.
-            root.appender("server").build(
+            log_root_builder.appender("server").build(
                 *config
                     .server
                     .logs
                     .level
                     .get("root")
-                    .unwrap_or(&log::LevelFilter::Warn),
+                    .unwrap_or(&log::LevelFilter::Error),
             ),
         )
         .map_err(anyhow::Error::new)


### PR DESCRIPTION
Log can now be correctly configured.

```toml
[server.logs.level]
# global logs for the server, all logs will be by default set to info.
server = "info"
# crate dependencies logs will be set to warn.
root = "warn"
# individual log levels, will override 'server' for this particular module.
receiver = "trace"
```