### PR TITLE
Rcpt Behavior

### DIFF
--- a/examples/config/doe_family/main.vsl
+++ b/examples/config/doe_family/main.vsl
@@ -8,14 +8,14 @@ import "objects" as doe;
 
   rcpt: [
     // jane will always be added as a bcc when jenny is part of the recipients.
-    action "bcc jenny" || if doe::jenny in ctx().rcpt { bcc(doe::jane) },
+    action "bcc jenny" || if doe::jenny in ctx().rcpt_list { bcc(doe::jane) },
   ],
 
   delivery: [
     action "setup delivery" ||
       // we loop over all recipients and deliver localy if any of them is part of the family.
       // otherwise, we simply deliver the email over SMTP.
-      for rcpt in ctx().rcpt {
+      for rcpt in ctx().rcpt_list {
         if rcpt in doe::family_addr { maildir(rcpt) } else { deliver(rcpt) }
       }
   ],

--- a/examples/vsl/rules/rcpt.vsl
+++ b/examples/vsl/rules/rcpt.vsl
@@ -2,9 +2,9 @@ import "rcpt_identifiers" as ident;
 
 #{
   rcpt: [
-    rule "test_ident" || if ident::john in ctx().rcpt.local_parts { next() } else { deny() },
-    rule "test_fqdn" || if ident::bar in ctx().rcpt.domains { next() } else { deny() },
-    rule "test_addr" || if ident::customer in ctx().rcpt { accept() } else { deny() },
+    rule "test_ident" || if ident::john in ctx().rcpt_list.local_parts { next() } else { deny() },
+    rule "test_fqdn" || if ident::bar in ctx().rcpt_list.domains { next() } else { deny() },
+    rule "test_addr" || if ident::customer in ctx().rcpt_list { accept() } else { deny() },
   ],
 
   postq: [

--- a/src/vsmtp/vsmtp-rule-engine/src/api/auth.rhai
+++ b/src/vsmtp/vsmtp-rule-engine/src/api/auth.rhai
@@ -39,7 +39,7 @@
 /// ```
 ///
 fn check_relay(allowed_hosts) {
-    for rcpt in ctx().rcpt {
+    for rcpt in ctx().rcpt_list {
         if !(ctx().is_authenticated || (ctx().client_ip in allowed_hosts))
             && !in_domain(rcpt) {
                 remove_rcpt(rcpt.to_string());

--- a/src/vsmtp/vsmtp-rule-engine/src/modules/mail_context.rs
+++ b/src/vsmtp/vsmtp-rule-engine/src/modules/mail_context.rs
@@ -140,14 +140,24 @@ pub mod mail_context {
         Ok(vsl_guard_ok!(this.read()).envelop.mail_from.clone())
     }
 
-    #[rhai_fn(global, get = "rcpt", return_raw, pure)]
-    pub fn rcpt(this: &mut Context) -> EngineResult<Vec<Address>> {
+    #[rhai_fn(global, get = "rcpt_list", return_raw, pure)]
+    pub fn rcpt_list(this: &mut Context) -> EngineResult<Vec<Address>> {
         Ok(vsl_guard_ok!(this.read())
             .envelop
             .rcpt
             .iter()
             .map(|rcpt| rcpt.address.clone())
             .collect())
+    }
+
+    #[rhai_fn(global, get = "rcpt", return_raw, pure)]
+    pub fn rcpt(this: &mut Context) -> EngineResult<Address> {
+        vsl_guard_ok!(this.read())
+            .envelop
+            .rcpt
+            .last()
+            .map(|rcpt| rcpt.address.clone())
+            .ok_or_else(|| "not recipients received yet".into())
     }
 
     #[rhai_fn(global, get = "mail_timestamp", return_raw, pure)]

--- a/src/vsmtp/vsmtp-rule-engine/src/modules/mail_context.rs
+++ b/src/vsmtp/vsmtp-rule-engine/src/modules/mail_context.rs
@@ -157,7 +157,7 @@ pub mod mail_context {
             .rcpt
             .last()
             .map(|rcpt| rcpt.address.clone())
-            .ok_or_else(|| "not recipients received yet".into())
+            .ok_or_else(|| "no recipient received yet".into())
     }
 
     #[rhai_fn(global, get = "mail_timestamp", return_raw, pure)]

--- a/src/vsmtp/vsmtp-rule-engine/src/tests/email/bcc/bcc.vsl
+++ b/src/vsmtp/vsmtp-rule-engine/src/tests/email/bcc/bcc.vsl
@@ -25,11 +25,11 @@ fn invalid_object(obj) {
 }
 
 fn add_bcc(bcc) {
-    if bcc in ctx().rcpt {
+    if bcc in ctx().rcpt_list {
         return deny();
     }
 
     bcc(bcc);
 
-    if bcc in ctx().rcpt { next() } else { deny() }
+    if bcc in ctx().rcpt_list { next() } else { deny() }
 }

--- a/src/vsmtp/vsmtp-rule-engine/src/tests/email/main.vsl
+++ b/src/vsmtp/vsmtp-rule-engine/src/tests/email/main.vsl
@@ -151,10 +151,10 @@
         },
 
         rule "check rewrites" || {
-            if "added@rcpt.com" in ctx().rcpt
-            && !("rcpt@toremove.org" in ctx().rcpt)
-            && "new@rcpt.net" in ctx().rcpt
-            && !("rcpt@torewrite.net" in ctx().rcpt)
+            if "added@rcpt.com" in ctx().rcpt_list
+            && !("rcpt@toremove.org" in ctx().rcpt_list)
+            && "new@rcpt.net" in ctx().rcpt_list
+            && !("rcpt@torewrite.net" in ctx().rcpt_list)
             && ctx().mail_from is "new@mailfrom.eu" {
                 next()
             } else {


### PR DESCRIPTION
# Summary of changes
## Changed
- rename `rcpt` vsl getter to `rcpt_list`.
## Added
- `rcpt` ctx getter, get the recipient from the latest `RCPT TO:` command.

```rust
#{
    rcpt: [
        rule "test rcpt" || {
            print("rcpt list:");
            for rcpt in ctx().rcpt_list {
                print(`=> ${rcpt}`);
            }

            print(`latest rcpt received ${ctx().rcpt}`);
            next()
        },
    ],
}
```

The rcpt stage is run every `RCPT TO:` command received.