### PR TITLE
Fix/doc config

### DIFF
--- a/fuzz/fuzz_targets/receiver.rs
+++ b/fuzz/fuzz_targets/receiver.rs
@@ -2,11 +2,11 @@
 use libfuzzer_sys::fuzz_target;
 use vsmtp_common::{
     mail_context::{MailContext, MessageBody},
-    CodeID,
+    CodeID, ConnectionKind
 };
 use vsmtp_config::Config;
 use vsmtp_rule_engine::rule_engine::RuleEngine;
-use vsmtp_server::{handle_connection, Connection, ConnectionKind, OnMail};
+use vsmtp_server::{handle_connection, Connection, OnMail};
 use vsmtp_test::receiver::Mock;
 
 struct FuzzOnMail;

--- a/src/vsmtp/src/lib.rs
+++ b/src/vsmtp/src/lib.rs
@@ -9,7 +9,6 @@
 #![warn(clippy::nursery)]
 #![warn(clippy::cargo)]
 //
-#![allow(clippy::doc_markdown)]
 #![allow(clippy::multiple_crate_versions)]
 
 mod args;

--- a/src/vsmtp/vsmtp-common/src/auth/mechanism.rs
+++ b/src/vsmtp/vsmtp-common/src/auth/mechanism.rs
@@ -13,7 +13,8 @@
  * You should have received a copy of the GNU General Public License along with
  * this program. If not, see https://www.gnu.org/licenses/.
  *
-*/
+ */
+
 /// List of supported SASL Mechanism
 /// See <https://www.iana.org/assignments/sasl-mechanisms/sasl-mechanisms.xhtml>
 #[derive(

--- a/src/vsmtp/vsmtp-common/src/lib.rs
+++ b/src/vsmtp/vsmtp-common/src/lib.rs
@@ -26,8 +26,7 @@
 #![warn(clippy::nursery)]
 #![warn(clippy::cargo)]
 //
-#![allow(clippy::doc_markdown)]
-#![allow(clippy::use_self)]
+#![allow(clippy::use_self)] // false positive with enums
 
 /// Default smtp port
 pub const SMTP_PORT: u16 = 25;

--- a/src/vsmtp/vsmtp-common/src/lib.rs
+++ b/src/vsmtp/vsmtp-common/src/lib.rs
@@ -39,6 +39,20 @@ pub const SUBMISSION_PORT: u16 = 587;
 /// Defined in [RFC8314](https://tools.ietf.org/html/rfc8314)
 pub const SUBMISSIONS_PORT: u16 = 465;
 
+/// Type of SMTP connection.
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, strum::Display)]
+pub enum ConnectionKind {
+    /// Connection coming for relay (MTA on port 25)
+    /// see <https://datatracker.ietf.org/doc/html/rfc5321>
+    Relay,
+    /// Connection coming for submission (MSA on port 587)
+    /// see <https://datatracker.ietf.org/doc/html/rfc6409>
+    Submission,
+    /// Connection coming for submissionS (MSA on port 465)
+    /// see <https://datatracker.ietf.org/doc/html/rfc8314>
+    Tunneled,
+}
+
 mod log_channels {
     pub const QUEUE: &str = "server::queue";
 }

--- a/src/vsmtp/vsmtp-common/src/libc_abstraction.rs
+++ b/src/vsmtp/vsmtp-common/src/libc_abstraction.rs
@@ -29,11 +29,11 @@ pub enum ForkResult {
 /// see fork(2) ERRORS
 ///
 /// * A system-imposed limit on the number of threads was encountered
-///   * the RLIMIT_NPROC soft resource limit was reached
+///   * the `RLIMIT_NPROC` soft resource limit was reached
 ///   * the kernel's system-wide limit on the number of processes and threads was reached
 ///   * the maximum number of PIDs was reached
 ///   * the PID limit imposed by the cgroup "process number" controller was reached.
-/// * The caller is operating under the SCHED_DEADLINE scheduling policy
+/// * The caller is operating under the `SCHED_DEADLINE` scheduling policy
 ///   and does not have the reset-on-fork flagset.
 /// * fork() is not supported on this platform
 /// * fork() failed to allocate the necessary kernel structures because memory is tight
@@ -154,7 +154,7 @@ pub fn initgroups(user: &str, gid: libc::gid_t) -> anyhow::Result<()> {
 ///
 /// # Errors
 ///
-/// * `@path` cannot be convert to CString
+/// * `@path` cannot be convert to `CString`
 /// * see chown(2) ERRORS
 pub fn chown(path: &std::path::Path, user: Option<u32>, group: Option<u32>) -> anyhow::Result<()> {
     let path = std::ffi::CString::new(path.to_string_lossy().as_bytes())?;
@@ -181,7 +181,7 @@ pub fn chown(path: &std::path::Path, user: Option<u32>, group: Option<u32>) -> a
 ///
 /// * `@name` contain an internal 0 byte
 ///
-/// see if_nametoindex(2) ERRORS
+/// see `if_nametoindex(2)` ERRORS
 /// * ENXIO: No index found for the @name
 pub fn if_nametoindex(name: &str) -> anyhow::Result<u32> {
     let ifname = std::ffi::CString::new(name)?;

--- a/src/vsmtp/vsmtp-common/src/message/mail.rs
+++ b/src/vsmtp/vsmtp-common/src/message/mail.rs
@@ -14,9 +14,10 @@
  * this program. If not, see https://www.gnu.org/licenses/.
  *
 */
+
 use super::mime_type::Mime;
 
-/// we use Vec instead of a HashMap because header ordering is important.
+/// we use Vec instead of a `HashMap` because header ordering is important.
 #[allow(clippy::module_name_repetitions)]
 pub type MailHeaders = Vec<(String, String)>;
 

--- a/src/vsmtp/vsmtp-common/src/type/address.rs
+++ b/src/vsmtp/vsmtp-common/src/type/address.rs
@@ -23,7 +23,7 @@ pub struct Address {
     full: String,
 }
 
-/// Syntax sugar Address object from dyn ToString
+/// Syntax sugar Address object from dyn `ToString`
 ///
 /// # Panics
 ///

--- a/src/vsmtp/vsmtp-common/src/type/reply.rs
+++ b/src/vsmtp/vsmtp-common/src/type/reply.rs
@@ -18,11 +18,19 @@
 use crate::ReplyCode;
 
 /// SMTP message send by the server to the client as defined in RFC5321#4.2
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Reply {
-    #[serde(flatten)]
     code: ReplyCode,
     text: String,
+}
+
+impl serde::Serialize for Reply {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&self.fold())
+    }
 }
 
 impl<'de> serde::Deserialize<'de> for Reply {
@@ -128,6 +136,8 @@ impl Reply {
     }
 
     ///
+    // TODO: should be private and called only when the object is construct,
+    // the result should be cached
     #[must_use]
     pub fn fold(&self) -> String {
         let prefix = match &self.code {

--- a/src/vsmtp/vsmtp-config/src/builder/validate.rs
+++ b/src/vsmtp/vsmtp-config/src/builder/validate.rs
@@ -17,9 +17,9 @@
 use super::{wants::WantsValidate, with::Builder};
 use crate::{
     config::{
-        ConfigApp, ConfigAppLogs, ConfigAppVSL, ConfigServer, ConfigServerInterfaces,
-        ConfigServerLogs, ConfigServerQueues, ConfigServerSMTP, ConfigServerSMTPError,
-        ConfigServerSMTPTimeoutClient, ConfigServerSystem, ConfigServerSystemThreadPool,
+        FieldApp, FieldAppLogs, FieldAppVSL, FieldServer, FieldServerInterfaces, FieldServerLogs,
+        FieldServerQueues, FieldServerSMTP, FieldServerSMTPError, FieldServerSMTPTimeoutClient,
+        FieldServerSystem, FieldServerSystemThreadPool,
     },
     Config,
 };
@@ -55,47 +55,47 @@ impl Builder<WantsValidate> {
 
         Config::ensure(Config {
             version_requirement: version.version_requirement,
-            server: ConfigServer {
+            server: FieldServer {
                 domain: srv.domain,
                 client_count_max: srv.client_count_max,
-                system: ConfigServerSystem {
+                system: FieldServerSystem {
                     user: srv_syst.user,
                     group: srv_syst.group,
                     group_local: srv_syst.group_local,
-                    thread_pool: ConfigServerSystemThreadPool {
+                    thread_pool: FieldServerSystemThreadPool {
                         receiver: srv_syst.thread_pool_receiver,
                         processing: srv_syst.thread_pool_processing,
                         delivery: srv_syst.thread_pool_delivery,
                     },
                 },
-                interfaces: ConfigServerInterfaces {
+                interfaces: FieldServerInterfaces {
                     addr: srv_inet.addr,
                     addr_submission: srv_inet.addr_submission,
                     addr_submissions: srv_inet.addr_submissions,
                 },
-                logs: ConfigServerLogs {
+                logs: FieldServerLogs {
                     filepath: srv_logs.filepath,
                     format: srv_logs.format,
                     level: srv_logs.level,
                     size_limit: srv_logs.size_limit,
                     archive_count: srv_logs.archive_count,
                 },
-                queues: ConfigServerQueues {
+                queues: FieldServerQueues {
                     dirpath: srv_delivery.dirpath,
                     working: srv_delivery.working,
                     delivery: srv_delivery.delivery,
                 },
                 tls: srv_tls.tls,
-                smtp: ConfigServerSMTP {
+                smtp: FieldServerSMTP {
                     rcpt_count_max: smtp_opt.rcpt_count_max,
                     disable_ehlo: smtp_opt.disable_ehlo,
                     required_extension: smtp_opt.required_extension,
-                    error: ConfigServerSMTPError {
+                    error: FieldServerSMTPError {
                         soft_count: smtp_error.error.soft_count,
                         hard_count: smtp_error.error.hard_count,
                         delay: smtp_error.error.delay,
                     },
-                    timeout_client: ConfigServerSMTPTimeoutClient {
+                    timeout_client: FieldServerSMTPTimeoutClient {
                         connect: smtp_error.timeout_client.connect,
                         helo: smtp_error.timeout_client.helo,
                         mail_from: smtp_error.timeout_client.mail_from,
@@ -108,12 +108,12 @@ impl Builder<WantsValidate> {
                 dns: dns.config,
                 r#virtual: virtual_entries.r#virtual,
             },
-            app: ConfigApp {
+            app: FieldApp {
                 dirpath: app.dirpath,
-                vsl: ConfigAppVSL {
+                vsl: FieldAppVSL {
                     filepath: app_vsl.filepath,
                 },
-                logs: ConfigAppLogs {
+                logs: FieldAppLogs {
                     filepath: app_logs.filepath,
                     level: app_logs.level,
                     format: app_logs.format,
@@ -208,7 +208,7 @@ impl Config {
             );
         }
 
-        let default_values = ConfigServerSMTP::default_smtp_codes();
+        let default_values = FieldServerSMTP::default_smtp_codes();
         let reply_codes = &mut config.server.smtp.codes;
 
         for key in <CodeID as strum::IntoEnumIterator>::iter() {

--- a/src/vsmtp/vsmtp-config/src/builder/validate.rs
+++ b/src/vsmtp/vsmtp-config/src/builder/validate.rs
@@ -16,18 +16,14 @@
 */
 use super::{wants::WantsValidate, with::Builder};
 use crate::{
-    config::{
+    config::field::{
         FieldApp, FieldAppLogs, FieldAppVSL, FieldServer, FieldServerInterfaces, FieldServerLogs,
         FieldServerQueues, FieldServerSMTP, FieldServerSMTPError, FieldServerSMTPTimeoutClient,
         FieldServerSystem, FieldServerSystemThreadPool,
     },
     Config,
 };
-use vsmtp_common::{
-    auth::Mechanism,
-    re::{anyhow, strum},
-    CodeID, Reply, ReplyCode,
-};
+use vsmtp_common::re::anyhow;
 
 impl Builder<WantsValidate> {
     ///
@@ -122,106 +118,6 @@ impl Builder<WantsValidate> {
                 },
             },
         })
-    }
-}
-
-fn mech_list_to_code(list: &[Mechanism]) -> String {
-    format!(
-        "AUTH {}\r\n",
-        list.iter()
-            .map(ToString::to_string)
-            .collect::<Vec<_>>()
-            .join(" ")
-    )
-}
-
-impl Config {
-    pub(crate) fn ensure(mut config: Self) -> anyhow::Result<Self> {
-        anyhow::ensure!(
-            config.app.logs.filepath != config.server.logs.filepath,
-            "System and Application logs cannot both be written in '{}' !",
-            config.app.logs.filepath.display()
-        );
-
-        anyhow::ensure!(
-            config.server.system.thread_pool.processing != 0
-                && config.server.system.thread_pool.receiver != 0
-                && config.server.system.thread_pool.delivery != 0,
-            "Worker threads cannot be set to 0"
-        );
-
-        {
-            let auth_mechanism_list: Option<(Vec<Mechanism>, Vec<Mechanism>)> = config
-                .server
-                .smtp
-                .auth
-                .as_ref()
-                .map(|auth| auth.mechanisms.iter().partition(|m| m.must_be_under_tls()));
-
-            config.server.smtp.codes.insert(
-                CodeID::EhloPain,
-                Reply::new(
-                    ReplyCode::Code { code: 250 },
-                    [
-                        &config.server.domain,
-                        "\r\n",
-                        &auth_mechanism_list
-                            .as_ref()
-                            .map(|(plain, secured)| {
-                                if config
-                                    .server
-                                    .smtp
-                                    .auth
-                                    .as_ref()
-                                    .map_or(false, |auth| auth.enable_dangerous_mechanism_in_clair)
-                                {
-                                    mech_list_to_code(&[secured.clone(), plain.clone()].concat())
-                                } else {
-                                    mech_list_to_code(secured)
-                                }
-                            })
-                            .unwrap_or_default(),
-                        "STARTTLS\r\n",
-                        "8BITMIME\r\n",
-                        "SMTPUTF8\r\n",
-                    ]
-                    .concat(),
-                ),
-            );
-
-            config.server.smtp.codes.insert(
-                CodeID::EhloSecured,
-                Reply::new(
-                    ReplyCode::Code { code: 250 },
-                    [
-                        &config.server.domain,
-                        "\r\n",
-                        &auth_mechanism_list
-                            .as_ref()
-                            .map(|(must_be_secured, _)| mech_list_to_code(must_be_secured))
-                            .unwrap_or_default(),
-                        "8BITMIME\r\n",
-                        "SMTPUTF8\r\n",
-                    ]
-                    .concat(),
-                ),
-            );
-        }
-
-        let default_values = FieldServerSMTP::default_smtp_codes();
-        let reply_codes = &mut config.server.smtp.codes;
-
-        for key in <CodeID as strum::IntoEnumIterator>::iter() {
-            reply_codes
-                .entry(key)
-                .or_insert_with_key(|key| default_values.get(key).unwrap().clone());
-
-            reply_codes.entry(key).and_modify(|reply| {
-                reply.set(reply.text().replace("{domain}", &config.server.domain));
-            });
-        }
-
-        Ok(config)
     }
 }
 

--- a/src/vsmtp/vsmtp-config/src/builder/wants.rs
+++ b/src/vsmtp/vsmtp-config/src/builder/wants.rs
@@ -20,10 +20,10 @@ use vsmtp_common::{re::log, CodeID, Reply};
 
 use crate::{
     config::{
-        ConfigQueueDelivery, ConfigQueueWorking, ConfigServerDNS, ConfigServerSMTPError,
-        ConfigServerSMTPTimeoutClient, ConfigServerTls,
+        FieldQueueDelivery, FieldQueueWorking, FieldServerDNS, FieldServerSMTPError,
+        FieldServerSMTPTimeoutClient, FieldServerTls,
     },
-    ConfigServerSMTPAuth, ConfigServerVirtual,
+    FieldServerSMTPAuth, FieldServerVirtual,
 };
 
 ///
@@ -76,14 +76,14 @@ pub struct WantsServerQueues {
 pub struct WantsServerTLSConfig {
     pub(crate) parent: WantsServerQueues,
     pub(super) dirpath: std::path::PathBuf,
-    pub(super) working: ConfigQueueWorking,
-    pub(super) delivery: ConfigQueueDelivery,
+    pub(super) working: FieldQueueWorking,
+    pub(super) delivery: FieldQueueDelivery,
 }
 
 ///
 pub struct WantsServerSMTPConfig1 {
     pub(crate) parent: WantsServerTLSConfig,
-    pub(super) tls: Option<ConfigServerTls>,
+    pub(super) tls: Option<FieldServerTls>,
 }
 
 ///
@@ -97,8 +97,8 @@ pub struct WantsServerSMTPConfig2 {
 ///
 pub struct WantsServerSMTPConfig3 {
     pub(crate) parent: WantsServerSMTPConfig2,
-    pub(super) error: ConfigServerSMTPError,
-    pub(super) timeout_client: ConfigServerSMTPTimeoutClient,
+    pub(super) error: FieldServerSMTPError,
+    pub(super) timeout_client: FieldServerSMTPTimeoutClient,
 }
 
 ///
@@ -110,7 +110,7 @@ pub struct WantsServerSMTPAuth {
 ///
 pub struct WantsApp {
     pub(crate) parent: WantsServerSMTPAuth,
-    pub(super) auth: Option<ConfigServerSMTPAuth>,
+    pub(super) auth: Option<FieldServerSMTPAuth>,
 }
 
 ///
@@ -138,11 +138,11 @@ pub struct WantsServerDNS {
 ///
 pub struct WantsServerVirtual {
     pub(crate) parent: WantsServerDNS,
-    pub(super) config: ConfigServerDNS,
+    pub(super) config: FieldServerDNS,
 }
 
 ///
 pub struct WantsValidate {
     pub(crate) parent: WantsServerVirtual,
-    pub(super) r#virtual: std::collections::BTreeMap<String, ConfigServerVirtual>,
+    pub(super) r#virtual: std::collections::BTreeMap<String, FieldServerVirtual>,
 }

--- a/src/vsmtp/vsmtp-config/src/builder/wants.rs
+++ b/src/vsmtp/vsmtp-config/src/builder/wants.rs
@@ -16,15 +16,11 @@
 */
 #![allow(clippy::module_name_repetitions)]
 
-use vsmtp_common::{re::log, CodeID, Reply};
-
-use crate::{
-    config::{
-        FieldQueueDelivery, FieldQueueWorking, FieldServerDNS, FieldServerSMTPError,
-        FieldServerSMTPTimeoutClient, FieldServerTls,
-    },
-    FieldServerSMTPAuth, FieldServerVirtual,
+use crate::field::{
+    FieldQueueDelivery, FieldQueueWorking, FieldServerDNS, FieldServerSMTPAuth,
+    FieldServerSMTPError, FieldServerSMTPTimeoutClient, FieldServerTls, FieldServerVirtual,
 };
+use vsmtp_common::{re::log, CodeID, Reply};
 
 ///
 pub struct WantsVersion(pub(crate) ());

--- a/src/vsmtp/vsmtp-config/src/builder/with.rs
+++ b/src/vsmtp/vsmtp-config/src/builder/with.rs
@@ -14,9 +14,6 @@
  * this program. If not, see https://www.gnu.org/licenses/.
  *
 */
-// this produce just too much false positive in this file
-#![allow(clippy::missing_const_for_fn)]
-
 use super::{
     wants::{
         WantsApp, WantsAppLogs, WantsAppVSL, WantsServer, WantsServerDNS, WantsServerInterfaces,
@@ -28,13 +25,13 @@ use super::{
 };
 use crate::{
     config::{
-        ConfigApp, ConfigAppLogs, ConfigQueueDelivery, ConfigQueueWorking, ConfigServer,
-        ConfigServerDNS, ConfigServerInterfaces, ConfigServerLogs, ConfigServerQueues,
-        ConfigServerSMTP, ConfigServerSMTPError, ConfigServerSMTPTimeoutClient, ConfigServerSystem,
-        ConfigServerSystemThreadPool, ConfigServerTls, ConfigServerVirtual, TlsSecurityLevel,
+        FieldApp, FieldAppLogs, FieldQueueDelivery, FieldQueueWorking, FieldServer, FieldServerDNS,
+        FieldServerInterfaces, FieldServerLogs, FieldServerQueues, FieldServerSMTP,
+        FieldServerSMTPError, FieldServerSMTPTimeoutClient, FieldServerSystem,
+        FieldServerSystemThreadPool, FieldServerTls, FieldServerVirtual, TlsSecurityLevel,
     },
     parser::{tls_certificate, tls_private_key},
-    ConfigServerSMTPAuth, ResolverOptsWrapper, TlsFile,
+    FieldServerSMTPAuth, ResolverOptsWrapper, TlsFile,
 };
 use vsmtp_common::{
     auth::Mechanism,
@@ -54,7 +51,7 @@ pub struct Builder<State> {
 impl Builder<WantsVersion> {
     /// # Panics
     ///
-    /// * CARGO_PKG_VERSION is not valid
+    /// * `CARGO_PKG_VERSION` is not valid
     #[must_use]
     pub fn with_current_version(self) -> Builder<WantsServer> {
         self.with_version_str(env!("CARGO_PKG_VERSION")).unwrap()
@@ -62,7 +59,7 @@ impl Builder<WantsVersion> {
 
     /// # Errors
     ///
-    /// * version_requirement is not valid format
+    /// * `version_requirement` is not valid format
     pub fn with_version_str(
         self,
         version_requirement: &str,
@@ -88,7 +85,7 @@ impl Builder<WantsServer> {
     ///
     #[must_use]
     pub fn with_hostname(self) -> Builder<WantsServerSystem> {
-        self.with_hostname_and_client_count_max(ConfigServer::default_client_count_max())
+        self.with_hostname_and_client_count_max(FieldServer::default_client_count_max())
     }
 
     ///
@@ -97,13 +94,13 @@ impl Builder<WantsServer> {
         self,
         client_count_max: i64,
     ) -> Builder<WantsServerSystem> {
-        self.with_server_name_and_client_count(&ConfigServer::hostname(), client_count_max)
+        self.with_server_name_and_client_count(&FieldServer::hostname(), client_count_max)
     }
 
     ///
     #[must_use]
     pub fn with_server_name(self, domain: &str) -> Builder<WantsServerSystem> {
-        self.with_server_name_and_client_count(domain, ConfigServer::default_client_count_max())
+        self.with_server_name_and_client_count(domain, FieldServer::default_client_count_max())
     }
 
     ///
@@ -128,12 +125,12 @@ impl Builder<WantsServerSystem> {
     #[must_use]
     pub fn with_default_system(self) -> Builder<WantsServerInterfaces> {
         self.with_system(
-            ConfigServerSystem::default_user(),
-            ConfigServerSystem::default_group(),
+            FieldServerSystem::default_user(),
+            FieldServerSystem::default_group(),
             None,
-            ConfigServerSystemThreadPool::default_receiver(),
-            ConfigServerSystemThreadPool::default_processing(),
-            ConfigServerSystemThreadPool::default_delivery(),
+            FieldServerSystemThreadPool::default_receiver(),
+            FieldServerSystemThreadPool::default_processing(),
+            FieldServerSystemThreadPool::default_delivery(),
         )
     }
 
@@ -146,8 +143,8 @@ impl Builder<WantsServerSystem> {
         thread_pool_delivery: usize,
     ) -> Builder<WantsServerInterfaces> {
         self.with_system(
-            ConfigServerSystem::default_user(),
-            ConfigServerSystem::default_group(),
+            FieldServerSystem::default_user(),
+            FieldServerSystem::default_group(),
             None,
             thread_pool_receiver,
             thread_pool_processing,
@@ -168,13 +165,14 @@ impl Builder<WantsServerSystem> {
             user,
             group,
             None,
-            ConfigServerSystemThreadPool::default_receiver(),
-            ConfigServerSystemThreadPool::default_processing(),
-            ConfigServerSystemThreadPool::default_delivery(),
+            FieldServerSystemThreadPool::default_receiver(),
+            FieldServerSystemThreadPool::default_processing(),
+            FieldServerSystemThreadPool::default_delivery(),
         )
     }
 
     ///
+    #[allow(clippy::missing_const_for_fn)]
     #[must_use]
     pub fn with_system(
         self,
@@ -238,7 +236,7 @@ impl Builder<WantsServerInterfaces> {
     ///
     #[must_use]
     pub fn with_ipv4_localhost(self) -> Builder<WantsServerLogs> {
-        let ipv4_localhost = ConfigServerInterfaces::ipv4_localhost();
+        let ipv4_localhost = FieldServerInterfaces::ipv4_localhost();
         self.with_interfaces(
             &ipv4_localhost.addr,
             &ipv4_localhost.addr_submission,
@@ -270,9 +268,9 @@ impl Builder<WantsServerLogs> {
     #[must_use]
     pub fn with_default_logs_settings(self) -> Builder<WantsServerQueues> {
         self.with_logs_settings(
-            ConfigServerLogs::default_filepath(),
-            ConfigServerLogs::default_format(),
-            ConfigServerLogs::default_level(),
+            FieldServerLogs::default_filepath(),
+            FieldServerLogs::default_format(),
+            FieldServerLogs::default_level(),
         )
     }
 
@@ -290,8 +288,8 @@ impl Builder<WantsServerLogs> {
                 filepath: filepath.into(),
                 format: format.into(),
                 level,
-                size_limit: ConfigServerLogs::default_size_limit(),
-                archive_count: ConfigServerLogs::default_archive_count(),
+                size_limit: FieldServerLogs::default_size_limit(),
+                archive_count: FieldServerLogs::default_archive_count(),
             },
         }
     }
@@ -301,7 +299,7 @@ impl Builder<WantsServerQueues> {
     ///
     #[must_use]
     pub fn with_default_delivery(self) -> Builder<WantsServerTLSConfig> {
-        self.with_spool_dir_and_default_queues(ConfigServerQueues::default_dirpath())
+        self.with_spool_dir_and_default_queues(FieldServerQueues::default_dirpath())
     }
 
     ///
@@ -312,8 +310,8 @@ impl Builder<WantsServerQueues> {
     ) -> Builder<WantsServerTLSConfig> {
         self.with_spool_dir_and_queues(
             spool_dir,
-            ConfigQueueWorking::default(),
-            ConfigQueueDelivery::default(),
+            FieldQueueWorking::default(),
+            FieldQueueDelivery::default(),
         )
     }
 
@@ -322,8 +320,8 @@ impl Builder<WantsServerQueues> {
     pub fn with_spool_dir_and_queues(
         self,
         spool_dir: impl Into<std::path::PathBuf>,
-        working: ConfigQueueWorking,
-        delivery: ConfigQueueDelivery,
+        working: FieldQueueWorking,
+        delivery: FieldQueueDelivery,
     ) -> Builder<WantsServerTLSConfig> {
         Builder::<WantsServerTLSConfig> {
             state: WantsServerTLSConfig {
@@ -341,8 +339,8 @@ impl Builder<WantsServerTLSConfig> {
     ///
     /// # Errors
     ///
-    /// * certificate is not valid
-    /// * private_key is not valid
+    /// * `certificate` is not valid
+    /// * `private_key` is not valid
     pub fn with_safe_tls_config(
         self,
         certificate: &str,
@@ -351,7 +349,7 @@ impl Builder<WantsServerTLSConfig> {
         Ok(Builder::<WantsServerSMTPConfig1> {
             state: WantsServerSMTPConfig1 {
                 parent: self.state,
-                tls: Some(ConfigServerTls {
+                tls: Some(FieldServerTls {
                     security_level: TlsSecurityLevel::May,
                     preempt_cipherlist: false,
                     handshake_timeout: std::time::Duration::from_millis(200),
@@ -364,13 +362,14 @@ impl Builder<WantsServerTLSConfig> {
                         inner: tls_private_key::from_string(private_key)?,
                         path: private_key.into(),
                     },
-                    cipher_suite: ConfigServerTls::default_cipher_suite(),
+                    cipher_suite: FieldServerTls::default_cipher_suite(),
                 }),
             },
         })
     }
 
     ///
+    #[allow(clippy::missing_const_for_fn)]
     #[must_use]
     pub fn without_tls_support(self) -> Builder<WantsServerSMTPConfig1> {
         Builder::<WantsServerSMTPConfig1> {
@@ -386,7 +385,7 @@ impl Builder<WantsServerSMTPConfig1> {
     ///
     #[must_use]
     pub fn with_default_smtp_options(self) -> Builder<WantsServerSMTPConfig2> {
-        self.with_rcpt_count_and_default(ConfigServerSMTP::default_rcpt_count_max())
+        self.with_rcpt_count_and_default(FieldServerSMTP::default_rcpt_count_max())
     }
 
     ///
@@ -399,8 +398,8 @@ impl Builder<WantsServerSMTPConfig1> {
             state: WantsServerSMTPConfig2 {
                 parent: self.state,
                 rcpt_count_max,
-                disable_ehlo: ConfigServerSMTP::default_disable_ehlo(),
-                required_extension: ConfigServerSMTP::default_required_extension(),
+                disable_ehlo: FieldServerSMTP::default_disable_ehlo(),
+                required_extension: FieldServerSMTP::default_required_extension(),
             },
         }
     }
@@ -413,8 +412,8 @@ impl Builder<WantsServerSMTPConfig2> {
         Builder::<WantsServerSMTPConfig3> {
             state: WantsServerSMTPConfig3 {
                 parent: self.state,
-                error: ConfigServerSMTPError::default(),
-                timeout_client: ConfigServerSMTPTimeoutClient::default(),
+                error: FieldServerSMTPError::default(),
+                timeout_client: FieldServerSMTPTimeoutClient::default(),
             },
         }
     }
@@ -432,12 +431,12 @@ impl Builder<WantsServerSMTPConfig2> {
         Builder::<WantsServerSMTPConfig3> {
             state: WantsServerSMTPConfig3 {
                 parent: self.state,
-                error: ConfigServerSMTPError {
+                error: FieldServerSMTPError {
                     soft_count,
                     hard_count,
                     delay,
                 },
-                timeout_client: ConfigServerSMTPTimeoutClient {
+                timeout_client: FieldServerSMTPTimeoutClient {
                     connect: *timeout_client
                         .get(&StateSMTP::Connect)
                         .unwrap_or(&std::time::Duration::from_millis(1000)),
@@ -483,6 +482,7 @@ impl Builder<WantsServerSMTPConfig3> {
 
 impl Builder<WantsServerSMTPAuth> {
     ///
+    #[allow(clippy::missing_const_for_fn)]
     #[must_use]
     pub fn without_auth(self) -> Builder<WantsApp> {
         Builder::<WantsApp> {
@@ -502,8 +502,8 @@ impl Builder<WantsServerSMTPAuth> {
     ) -> Builder<WantsApp> {
         self.with_auth(
             must_be_authenticated,
-            ConfigServerSMTPAuth::default_enable_dangerous_mechanism_in_clair(),
-            ConfigServerSMTPAuth::default_mechanisms(),
+            FieldServerSMTPAuth::default_enable_dangerous_mechanism_in_clair(),
+            FieldServerSMTPAuth::default_mechanisms(),
             attempt_count_max,
         )
     }
@@ -520,7 +520,7 @@ impl Builder<WantsServerSMTPAuth> {
         Builder::<WantsApp> {
             state: WantsApp {
                 parent: self.state,
-                auth: Some(ConfigServerSMTPAuth {
+                auth: Some(FieldServerSMTPAuth {
                     must_be_authenticated,
                     enable_dangerous_mechanism_in_clair,
                     mechanisms,
@@ -535,7 +535,7 @@ impl Builder<WantsApp> {
     ///
     #[must_use]
     pub fn with_default_app(self) -> Builder<WantsAppVSL> {
-        self.with_app_at_location(ConfigApp::default_dirpath())
+        self.with_app_at_location(FieldApp::default_dirpath())
     }
 
     ///
@@ -556,6 +556,7 @@ impl Builder<WantsApp> {
 impl Builder<WantsAppVSL> {
     ///
     #[must_use]
+    #[allow(clippy::missing_const_for_fn)]
     pub fn with_default_vsl_settings(self) -> Builder<WantsAppLogs> {
         Builder::<WantsAppLogs> {
             state: WantsAppLogs {
@@ -581,7 +582,7 @@ impl Builder<WantsAppLogs> {
     ///
     #[must_use]
     pub fn with_default_app_logs(self) -> Builder<WantsServerDNS> {
-        self.with_app_logs_at(ConfigAppLogs::default_filepath())
+        self.with_app_logs_at(FieldAppLogs::default_filepath())
     }
 
     ///
@@ -592,10 +593,10 @@ impl Builder<WantsAppLogs> {
     ) -> Builder<WantsServerDNS> {
         self.with_app_logs_level_and_format(
             filepath,
-            ConfigAppLogs::default_level(),
-            ConfigAppLogs::default_format(),
-            ConfigAppLogs::default_size_limit(),
-            ConfigAppLogs::default_archive_count(),
+            FieldAppLogs::default_level(),
+            FieldAppLogs::default_format(),
+            FieldAppLogs::default_size_limit(),
+            FieldAppLogs::default_archive_count(),
         )
     }
 
@@ -629,7 +630,7 @@ impl Builder<WantsServerDNS> {
         Builder::<WantsServerVirtual> {
             state: WantsServerVirtual {
                 parent: self.state,
-                config: ConfigServerDNS::Google {
+                config: FieldServerDNS::Google {
                     options: ResolverOptsWrapper::default(),
                 },
             },
@@ -642,7 +643,7 @@ impl Builder<WantsServerDNS> {
         Builder::<WantsServerVirtual> {
             state: WantsServerVirtual {
                 parent: self.state,
-                config: ConfigServerDNS::CloudFlare {
+                config: FieldServerDNS::CloudFlare {
                     options: ResolverOptsWrapper::default(),
                 },
             },
@@ -651,17 +652,19 @@ impl Builder<WantsServerDNS> {
 
     /// dns resolutions will be made using the system configuration.
     /// (/etc/resolv.conf on unix systems & the registry on Windows).
+    #[allow(clippy::missing_const_for_fn)]
     #[must_use]
     pub fn with_system_dns(self) -> Builder<WantsServerVirtual> {
         Builder::<WantsServerVirtual> {
             state: WantsServerVirtual {
                 parent: self.state,
-                config: ConfigServerDNS::System,
+                config: FieldServerDNS::System,
             },
         }
     }
 
     /// dns resolutions will be made using the following dns configuration.
+    #[allow(clippy::missing_const_for_fn)]
     #[must_use]
     pub fn with_dns(
         self,
@@ -671,7 +674,7 @@ impl Builder<WantsServerDNS> {
         Builder::<WantsServerVirtual> {
             state: WantsServerVirtual {
                 parent: self.state,
-                config: ConfigServerDNS::Custom { config, options },
+                config: FieldServerDNS::Custom { config, options },
             },
         }
     }
@@ -684,7 +687,7 @@ pub struct VirtualEntry {
     /// path to the certificate and private key used for tls.
     pub tls: Option<(String, String)>,
     /// dns configuration.
-    pub dns: Option<ConfigServerDNS>,
+    pub dns: Option<FieldServerDNS>,
 }
 
 impl Builder<WantsServerVirtual> {
@@ -715,13 +718,13 @@ impl Builder<WantsServerVirtual> {
             r#virtual.insert(
                 entry.domain.clone(),
                 match (entry.tls.as_ref(), entry.dns.as_ref()) {
-                    (None, None) => ConfigServerVirtual::new(),
-                    (None, Some(dns_config)) => ConfigServerVirtual::with_dns(dns_config.clone())?,
+                    (None, None) => FieldServerVirtual::new(),
+                    (None, Some(dns_config)) => FieldServerVirtual::with_dns(dns_config.clone())?,
                     (Some((certificate, private_key)), None) => {
-                        ConfigServerVirtual::with_tls(certificate, private_key)?
+                        FieldServerVirtual::with_tls(certificate, private_key)?
                     }
                     (Some((certificate, private_key)), Some(dns_config)) => {
-                        ConfigServerVirtual::with_tls_and_dns(
+                        FieldServerVirtual::with_tls_and_dns(
                             certificate,
                             private_key,
                             dns_config.clone(),

--- a/src/vsmtp/vsmtp-config/src/builder/with.rs
+++ b/src/vsmtp/vsmtp-config/src/builder/with.rs
@@ -14,24 +14,21 @@
  * this program. If not, see https://www.gnu.org/licenses/.
  *
 */
-use super::{
-    wants::{
-        WantsApp, WantsAppLogs, WantsAppVSL, WantsServer, WantsServerDNS, WantsServerInterfaces,
-        WantsServerLogs, WantsServerQueues, WantsServerSMTPConfig1, WantsServerSMTPConfig2,
-        WantsServerSMTPConfig3, WantsServerSystem, WantsServerTLSConfig, WantsValidate,
-        WantsVersion,
-    },
-    WantsServerSMTPAuth, WantsServerVirtual,
+use super::wants::{
+    WantsApp, WantsAppLogs, WantsAppVSL, WantsServer, WantsServerDNS, WantsServerInterfaces,
+    WantsServerLogs, WantsServerQueues, WantsServerSMTPAuth, WantsServerSMTPConfig1,
+    WantsServerSMTPConfig2, WantsServerSMTPConfig3, WantsServerSystem, WantsServerTLSConfig,
+    WantsServerVirtual, WantsValidate, WantsVersion,
 };
 use crate::{
-    config::{
+    field::{
         FieldApp, FieldAppLogs, FieldQueueDelivery, FieldQueueWorking, FieldServer, FieldServerDNS,
         FieldServerInterfaces, FieldServerLogs, FieldServerQueues, FieldServerSMTP,
-        FieldServerSMTPError, FieldServerSMTPTimeoutClient, FieldServerSystem,
-        FieldServerSystemThreadPool, FieldServerTls, FieldServerVirtual, TlsSecurityLevel,
+        FieldServerSMTPAuth, FieldServerSMTPError, FieldServerSMTPTimeoutClient, FieldServerSystem,
+        FieldServerSystemThreadPool, FieldServerTls, FieldServerVirtual, ResolverOptsWrapper,
+        TlsFile, TlsSecurityLevel,
     },
     parser::{tls_certificate, tls_private_key},
-    FieldServerSMTPAuth, ResolverOptsWrapper, TlsFile,
 };
 use vsmtp_common::{
     auth::Mechanism,

--- a/src/vsmtp/vsmtp-config/src/config.rs
+++ b/src/vsmtp/vsmtp-config/src/config.rs
@@ -15,361 +15,536 @@
  *
 */
 #![allow(clippy::use_self)] // false positive
-#![allow(missing_docs)]
 
 use serde_with::serde_as;
 use vsmtp_common::{auth::Mechanism, re::log, CodeID, Reply};
 
+/// This structure contains all the field to configure the server at the startup.
 ///
+/// This structure will be loaded from a configuration file `-c, --config`
+/// argument of the program. See [`crate::Config::from_toml`].
+///
+/// All field are optional and defaulted if missing.
+///
+/// You can also use the builder [`Config::builder`] to use the builder pattern,
+/// and create an instance programmatically.
+///
+/// You can find examples of configuration files in
+/// <https://github.com/viridIT/vSMTP/tree/develop/examples/config>
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct Config {
+    /// vSMTP's version requirement to parse this configuration file.
     #[serde(
         serialize_with = "crate::parser::semver::serialize",
         deserialize_with = "crate::parser::semver::deserialize"
     )]
     pub version_requirement: semver::VersionReq,
+    /// see [`field::FieldServer`]
     #[serde(default)]
-    pub server: FieldServer,
+    pub server: field::FieldServer,
+    /// see [`field::FieldApp`]
     #[serde(default)]
-    pub app: FieldApp,
+    pub app: field::FieldApp,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct FieldServer {
-    // TODO: parse valid fqdn
-    #[serde(default = "FieldServer::hostname")]
-    pub domain: String,
-    #[serde(default = "FieldServer::default_client_count_max")]
-    pub client_count_max: i64,
-    #[serde(default)]
-    pub system: FieldServerSystem,
-    #[serde(default)]
-    pub interfaces: FieldServerInterfaces,
-    #[serde(default)]
-    pub logs: FieldServerLogs,
-    #[serde(default)]
-    pub queues: FieldServerQueues,
-    pub tls: Option<FieldServerTls>,
-    #[serde(default)]
-    pub smtp: FieldServerSMTP,
-    #[serde(default)]
-    pub dns: FieldServerDNS,
-    #[serde(default)]
-    pub r#virtual: std::collections::BTreeMap<String, FieldServerVirtual>,
-}
+/// The inner field of the `vSMTP`'s configuration.
+#[allow(clippy::module_name_repetitions)]
+pub mod field {
+    pub use super::*;
 
-#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct FieldServerSystem {
-    #[serde(default = "FieldServerSystem::default_user")]
-    #[serde(
-        serialize_with = "crate::parser::syst_user::serialize",
-        deserialize_with = "crate::parser::syst_user::deserialize"
-    )]
-    pub user: users::User,
-    #[serde(default = "FieldServerSystem::default_group")]
-    #[serde(
-        serialize_with = "crate::parser::syst_group::serialize",
-        deserialize_with = "crate::parser::syst_group::deserialize"
-    )]
-    pub group: users::Group,
-    #[serde(default)]
-    #[serde(
-        serialize_with = "crate::parser::syst_group::opt_serialize",
-        deserialize_with = "crate::parser::syst_group::opt_deserialize"
-    )]
-    pub group_local: Option<users::Group>,
-    #[serde(default)]
-    pub thread_pool: FieldServerSystemThreadPool,
-}
-
-impl PartialEq for FieldServerSystem {
-    fn eq(&self, other: &Self) -> bool {
-        self.user.uid() == other.user.uid()
-            && self.group.gid() == other.group.gid()
-            && self.thread_pool == other.thread_pool
+    /// This structure contains all the field to configure the server at the startup.
+    #[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+    #[serde(deny_unknown_fields)]
+    pub struct FieldServer {
+        /// Name of the server.
+        ///
+        /// Used with the response [`CodeID::Greetings`], and [`CodeID::Helo`],
+        /// and [`CodeID::EhloPain`], and [`CodeID::EhloSecured`].
+        // TODO: parse valid fqdn
+        #[serde(default = "FieldServer::hostname")]
+        pub domain: String,
+        /// Maximum number of client served at the same time.
+        ///
+        /// The client will be rejected if the server is full.
+        ///
+        /// If this value is `-1`, then the server will accept any number of client.
+        #[serde(default = "FieldServer::default_client_count_max")]
+        pub client_count_max: i64,
+        /// see [`FieldServerSystem`]
+        #[serde(default)]
+        pub system: FieldServerSystem,
+        /// see [`FieldServerInterfaces`]
+        #[serde(default)]
+        pub interfaces: FieldServerInterfaces,
+        /// see [`FieldServerLogs`]
+        #[serde(default)]
+        pub logs: FieldServerLogs,
+        /// see [`FieldServerQueues`]
+        #[serde(default)]
+        pub queues: FieldServerQueues,
+        /// see [`FieldServerTls`]
+        pub tls: Option<FieldServerTls>,
+        /// see [`FieldServerSMTP`]
+        #[serde(default)]
+        pub smtp: FieldServerSMTP,
+        /// see [`FieldServerDNS`]
+        #[serde(default)]
+        pub dns: FieldServerDNS,
+        /// see [`FieldServerVirtual`]
+        #[serde(default)]
+        pub r#virtual: std::collections::BTreeMap<String, FieldServerVirtual>,
     }
-}
 
-impl Eq for FieldServerSystem {}
-
-#[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct FieldServerSystemThreadPool {
-    pub receiver: usize,
-    pub processing: usize,
-    pub delivery: usize,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct FieldServerInterfaces {
-    #[serde(default)]
-    #[serde(deserialize_with = "crate::parser::socket_addr::deserialize")]
-    pub addr: Vec<std::net::SocketAddr>,
-    #[serde(default)]
-    #[serde(deserialize_with = "crate::parser::socket_addr::deserialize")]
-    pub addr_submission: Vec<std::net::SocketAddr>,
-    #[serde(default)]
-    #[serde(deserialize_with = "crate::parser::socket_addr::deserialize")]
-    pub addr_submissions: Vec<std::net::SocketAddr>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct FieldServerLogs {
-    #[serde(default = "FieldServerLogs::default_filepath")]
-    pub filepath: std::path::PathBuf,
-    #[serde(default = "FieldServerLogs::default_format")]
-    pub format: String,
-    #[serde(default = "FieldServerLogs::default_level")]
-    pub level: std::collections::BTreeMap<String, log::LevelFilter>,
-    #[serde(default = "FieldServerLogs::default_size_limit")]
-    pub size_limit: u64,
-    #[serde(default = "FieldServerLogs::default_archive_count")]
-    pub archive_count: u32,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct FieldQueueWorking {
-    #[serde(default = "FieldQueueWorking::default_channel_size")]
-    pub channel_size: usize,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct FieldQueueDelivery {
-    #[serde(default = "FieldQueueDelivery::default_channel_size")]
-    pub channel_size: usize,
-    #[serde(default = "FieldQueueDelivery::default_deferred_retry_max")]
-    pub deferred_retry_max: usize,
-    #[serde(with = "humantime_serde")]
-    #[serde(default = "FieldQueueDelivery::default_deferred_retry_period")]
-    pub deferred_retry_period: std::time::Duration,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct FieldServerQueues {
-    pub dirpath: std::path::PathBuf,
-    #[serde(default)]
-    pub working: FieldQueueWorking,
-    #[serde(default)]
-    pub delivery: FieldQueueDelivery,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct FieldServerVirtual {
-    pub tls: Option<FieldServerVirtualTls>,
-    pub dns: Option<FieldServerDNS>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct FieldServerVirtualTls {
-    #[serde(
-        serialize_with = "crate::parser::tls_protocol_version::serialize",
-        deserialize_with = "crate::parser::tls_protocol_version::deserialize"
-    )]
-    pub protocol_version: Vec<rustls::ProtocolVersion>,
-    pub certificate: TlsFile<rustls::Certificate>,
-    pub private_key: TlsFile<rustls::PrivateKey>,
-    #[serde(default = "FieldServerVirtualTls::default_sender_security_level")]
-    pub sender_security_level: TlsSecurityLevel,
-}
-
-/// If a TLS configuration is provided, configure how the connection should be treated
-#[derive(Debug, Copy, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
-pub enum TlsSecurityLevel {
-    /// Connection may stay in plain text for theirs transaction
-    ///
-    /// Connection may upgrade at any moment with a TLS tunnel (using STARTTLS mechanism)
-    May,
-    /// Connection must be under a TLS tunnel (using STARTTLS mechanism or using port 465)
-    Encrypt,
-    /// DANE protocol using TLSA dns records to establish a secure connection with a distant server.
-    Dane { port: u16 },
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
-#[serde(transparent)]
-pub struct TlsFile<T> {
-    #[serde(skip_serializing)]
-    pub inner: T,
-    pub path: std::path::PathBuf,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct FieldServerTls {
-    pub security_level: TlsSecurityLevel,
-    pub preempt_cipherlist: bool,
-    #[serde(with = "humantime_serde")]
-    pub handshake_timeout: std::time::Duration,
-    #[serde(
-        serialize_with = "crate::parser::tls_protocol_version::serialize",
-        deserialize_with = "crate::parser::tls_protocol_version::deserialize"
-    )]
-    pub protocol_version: Vec<rustls::ProtocolVersion>,
-    #[serde(
-        serialize_with = "crate::parser::tls_cipher_suite::serialize",
-        deserialize_with = "crate::parser::tls_cipher_suite::deserialize",
-        default = "FieldServerTls::default_cipher_suite"
-    )]
-    pub cipher_suite: Vec<rustls::CipherSuite>,
-    pub certificate: TlsFile<rustls::Certificate>,
-    pub private_key: TlsFile<rustls::PrivateKey>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct FieldServerSMTPError {
-    pub soft_count: i64,
-    pub hard_count: i64,
-    #[serde(with = "humantime_serde")]
-    pub delay: std::time::Duration,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct FieldServerSMTPTimeoutClient {
-    #[serde(with = "humantime_serde")]
-    pub connect: std::time::Duration,
-    #[serde(with = "humantime_serde")]
-    pub helo: std::time::Duration,
-    #[serde(with = "humantime_serde")]
-    pub mail_from: std::time::Duration,
-    #[serde(with = "humantime_serde")]
-    pub rcpt_to: std::time::Duration,
-    #[serde(with = "humantime_serde")]
-    pub data: std::time::Duration,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct FieldServerSMTPAuth {
-    #[serde(default = "FieldServerSMTPAuth::default_must_be_authenticated")]
-    pub must_be_authenticated: bool,
-    #[serde(default = "FieldServerSMTPAuth::default_enable_dangerous_mechanism_in_clair")]
-    pub enable_dangerous_mechanism_in_clair: bool,
-    #[serde(default = "FieldServerSMTPAuth::default_mechanisms")]
-    pub mechanisms: Vec<Mechanism>,
-    #[serde(default = "FieldServerSMTPAuth::default_attempt_count_max")]
-    pub attempt_count_max: i64,
-}
-
-#[serde_as]
-#[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct FieldServerSMTP {
-    #[serde(default = "FieldServerSMTP::default_rcpt_count_max")]
-    pub rcpt_count_max: usize,
-    #[serde(default = "FieldServerSMTP::default_disable_ehlo")]
-    pub disable_ehlo: bool,
-    // TODO: parse extension enum
-    #[serde(default = "FieldServerSMTP::default_required_extension")]
-    pub required_extension: Vec<String>,
-    #[serde(default)]
-    pub error: FieldServerSMTPError,
-    #[serde(default)]
-    pub timeout_client: FieldServerSMTPTimeoutClient,
-    #[serde(default)]
-    #[serde_as(as = "std::collections::BTreeMap<serde_with::DisplayFromStr, _>")]
-    pub codes: std::collections::BTreeMap<CodeID, Reply>,
-    // NOTE: extension settings here
-    pub auth: Option<FieldServerSMTPAuth>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
-#[allow(clippy::large_enum_variant)]
-#[serde(tag = "type", deny_unknown_fields)]
-pub enum FieldServerDNS {
-    #[serde(rename = "system")]
-    System,
-    #[serde(rename = "google")]
-    Google {
+    /// The field related to the privileges used by `vSMTP`.
+    #[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+    #[serde(deny_unknown_fields)]
+    pub struct FieldServerSystem {
+        /// User running the server after the drop of privileges using `setuid`.
+        #[serde(default = "FieldServerSystem::default_user")]
+        #[serde(
+            serialize_with = "crate::parser::syst_user::serialize",
+            deserialize_with = "crate::parser::syst_user::deserialize"
+        )]
+        pub user: users::User,
+        /// Group running the server after the drop of privileges using `setgid`.
+        #[serde(default = "FieldServerSystem::default_group")]
+        #[serde(
+            serialize_with = "crate::parser::syst_group::serialize",
+            deserialize_with = "crate::parser::syst_group::deserialize"
+        )]
+        pub group: users::Group,
+        /// Group right set for the local delivery (maildir/mbox).
         #[serde(default)]
-        options: ResolverOptsWrapper,
-    },
-    #[serde(rename = "cloudflare")]
-    CloudFlare {
+        #[serde(
+            serialize_with = "crate::parser::syst_group::opt_serialize",
+            deserialize_with = "crate::parser::syst_group::opt_deserialize"
+        )]
+        pub group_local: Option<users::Group>,
+        /// see [`FieldServerSystemThreadPool`]
         #[serde(default)]
-        options: ResolverOptsWrapper,
-    },
-    #[serde(rename = "custom")]
-    Custom {
-        config: trust_dns_resolver::config::ResolverConfig,
+        pub thread_pool: FieldServerSystemThreadPool,
+    }
+
+    impl PartialEq for FieldServerSystem {
+        fn eq(&self, other: &Self) -> bool {
+            self.user.uid() == other.user.uid()
+                && self.group.gid() == other.group.gid()
+                && self.group_local.as_ref().map(users::Group::gid)
+                    == other.group_local.as_ref().map(users::Group::gid)
+                && self.thread_pool == other.thread_pool
+        }
+    }
+
+    impl Eq for FieldServerSystem {}
+
+    /// The field related to the thread allocation.
+    #[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+    #[serde(deny_unknown_fields)]
+    pub struct FieldServerSystemThreadPool {
+        /// Number of thread used by the pool `receiver`.
+        ///
+        /// This pool receive the client connection and handle the SMTP transaction.
+        pub receiver: usize,
+        /// Number of thread used by the pool `processing`.
+        ///
+        /// This pool forward the mails received by the `receiver` pool to the `delivery` pool.
+        ///
+        /// The mails treated has been accepted with a code [`CodeID::Ok`].
+        ///
+        /// "Offline" modification are applied here.
+        pub processing: usize,
+        /// Number of thread used by the pool `delivery`.
+        ///
+        /// This pool send the mails to the recipient, and handle the [`vsmtp_common::queue::Queue`]
+        pub delivery: usize,
+    }
+
+    /// Address served by `vSMTP`. Either ipv4 or ipv6.
+    #[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+    #[serde(deny_unknown_fields)]
+    pub struct FieldServerInterfaces {
+        /// List of address for the protocol SMTP. see [`vsmtp_common::ConnectionKind::Relay`]
         #[serde(default)]
-        options: ResolverOptsWrapper,
-    },
-}
+        #[serde(deserialize_with = "crate::parser::socket_addr::deserialize")]
+        pub addr: Vec<std::net::SocketAddr>,
+        /// List of address for the protocol ESMTPA. see [`vsmtp_common::ConnectionKind::Submission`]
+        #[serde(default)]
+        #[serde(deserialize_with = "crate::parser::socket_addr::deserialize")]
+        pub addr_submission: Vec<std::net::SocketAddr>,
+        /// List of address for the protocol ESMTPSA. see [`vsmtp_common::ConnectionKind::Tunneled`]
+        #[serde(default)]
+        #[serde(deserialize_with = "crate::parser::socket_addr::deserialize")]
+        pub addr_submissions: Vec<std::net::SocketAddr>,
+    }
 
-// TODO: remove that and use serde_with
-#[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
-#[allow(clippy::struct_excessive_bools)]
-pub struct ResolverOptsWrapper {
-    /// Specify the timeout for a request. Defaults to 5 seconds
-    #[serde(with = "humantime_serde")]
-    #[serde(default = "ResolverOptsWrapper::default_timeout")]
-    pub timeout: std::time::Duration,
-    /// Number of retries after lookup failure before giving up. Defaults to 2
-    #[serde(default = "ResolverOptsWrapper::default_attempts")]
-    pub attempts: usize,
-    /// Rotate through the resource records in the response (if there is more than one for a given name)
-    #[serde(default = "ResolverOptsWrapper::default_rotate")]
-    pub rotate: bool,
-    /// Use DNSSec to validate the request
-    #[serde(default = "ResolverOptsWrapper::default_dnssec")]
-    pub dnssec: bool,
-    /// The ip_strategy for the Resolver to use when lookup Ipv4 or Ipv6 addresses
-    #[serde(default = "ResolverOptsWrapper::default_ip_strategy")]
-    pub ip_strategy: trust_dns_resolver::config::LookupIpStrategy,
-    /// Cache size is in number of records (some records can be large)
-    #[serde(default = "ResolverOptsWrapper::default_cache_size")]
-    pub cache_size: usize,
-    /// Check /ect/hosts file before dns requery (only works for unix like OS)
-    #[serde(default = "ResolverOptsWrapper::default_use_hosts_file")]
-    pub use_hosts_file: bool,
-    /// Number of concurrent requests per query
-    ///
-    /// Where more than one nameserver is configured, this configures the resolver to send queries
-    /// to a number of servers in parallel. Defaults to 2; 0 or 1 will execute requests serially.
-    #[serde(default = "ResolverOptsWrapper::default_num_concurrent_reqs")]
-    pub num_concurrent_reqs: usize,
-}
+    /// The field related to the logs.
+    #[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+    #[serde(deny_unknown_fields)]
+    pub struct FieldServerLogs {
+        /// Filepath of the server's log.
+        ///
+        /// Once the file as reached [`FieldServerLogs::size_limit`], an archive is created
+        /// in the folder `{filepath}-ar`, named `trace.{N}.gz` (N being the number of archive).
+        #[serde(default = "FieldServerLogs::default_filepath")]
+        pub filepath: std::path::PathBuf,
+        /// Format of the output, see [`log4rs::encode::pattern`]
+        #[serde(default = "FieldServerLogs::default_format")]
+        pub format: String,
+        /// Customize the log level of the different part of the program.
+        #[serde(default = "FieldServerLogs::default_level")]
+        pub level: std::collections::BTreeMap<String, log::LevelFilter>,
+        /// Size limit of the content in [`FieldServerLogs::filepath`] before archiving.
+        #[serde(default = "FieldServerLogs::default_size_limit")]
+        pub size_limit: u64,
+        /// Number maximum of archive kept, the excess is deleted.
+        #[serde(default = "FieldServerLogs::default_archive_count")]
+        pub archive_count: u32,
+    }
 
-#[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct FieldAppVSL {
-    pub filepath: Option<std::path::PathBuf>,
-}
+    /// The configuration of the [`vsmtp_common::queue::Queue::Working`]
+    #[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+    #[serde(deny_unknown_fields)]
+    pub struct FieldQueueWorking {
+        /// Size of the [`vsmtp_common::re::tokio::sync::mpsc::channel`]
+        #[serde(default = "FieldQueueWorking::default_channel_size")]
+        pub channel_size: usize,
+    }
 
-#[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct FieldAppLogs {
-    #[serde(default = "FieldAppLogs::default_filepath")]
-    pub filepath: std::path::PathBuf,
-    #[serde(default = "FieldAppLogs::default_level")]
-    pub level: log::LevelFilter,
-    #[serde(default = "FieldAppLogs::default_format")]
-    pub format: String,
-    #[serde(default = "FieldAppLogs::default_size_limit")]
-    pub size_limit: u64,
-    #[serde(default = "FieldAppLogs::default_archive_count")]
-    pub archive_count: u32,
-}
+    /// The configuration of the [`vsmtp_common::queue::Queue::Deliver`] and the [`vsmtp_common::queue::Queue::Deferred`]
+    #[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+    #[serde(deny_unknown_fields)]
+    pub struct FieldQueueDelivery {
+        /// Size of the [`vsmtp_common::re::tokio::sync::mpsc::channel`]
+        #[serde(default = "FieldQueueDelivery::default_channel_size")]
+        pub channel_size: usize,
+        /// Maximum number of attempt to deliver the mail before moving it to the [`vsmtp_common::queue::Queue::Dead`]
+        #[serde(default = "FieldQueueDelivery::default_deferred_retry_max")]
+        pub deferred_retry_max: usize,
+        /// The mail in the  [`vsmtp_common::queue::Queue::Deferred`] are resend in a clock with this period.
+        #[serde(with = "humantime_serde")]
+        #[serde(default = "FieldQueueDelivery::default_deferred_retry_period")]
+        pub deferred_retry_period: std::time::Duration,
+    }
 
-#[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct FieldApp {
-    #[serde(default = "FieldApp::default_dirpath")]
-    pub dirpath: std::path::PathBuf,
-    #[serde(default)]
-    pub vsl: FieldAppVSL,
-    #[serde(default)]
-    pub logs: FieldAppLogs,
+    /// The configuration of the filesystem for the [`vsmtp_common::queue::Queue`].
+    #[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+    #[serde(deny_unknown_fields)]
+    pub struct FieldServerQueues {
+        /// Path of the spool folder.
+        ///
+        /// The structure of the spool is the following:
+        ///
+        /// ```shell
+        /// $> tree -L 2 /var/spool/vsmtp
+        /// /var/spool/vsmtp
+        /// ├── dead                   # mail failed to be delivered too many times
+        /// ├── deferred               # mail failed to be delivered (1..N) times
+        /// ├── deliver                # mail to be delivered
+        /// ├── mails                  # the message body (received between DATA and "<CRLF>.<CRLF>"
+        /// │   ├── <msg-id>.eml       # this file has not been modified (and stay in eml format)
+        /// │   └── <msg-id-2>.json    # this file has been parsed, and stored in .json
+        /// └── working                # mail to be processed
+        ///
+        pub dirpath: std::path::PathBuf,
+        /// see [`FieldQueueWorking`]
+        #[serde(default)]
+        pub working: FieldQueueWorking,
+        /// see [`FieldQueueDelivery`]
+        #[serde(default)]
+        pub delivery: FieldQueueDelivery,
+    }
+
+    /// The configuration of one virtual entry for the server.
+    #[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+    #[serde(deny_unknown_fields)]
+    pub struct FieldServerVirtual {
+        /// see [`FieldServerVirtualTls`]
+        pub tls: Option<FieldServerVirtualTls>,
+        /// see [`FieldServerDNS`]
+        pub dns: Option<FieldServerDNS>,
+    }
+
+    /// The TLS parameter for the **OUTGOING SIDE** of the virtual entry.
+    #[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+    #[serde(deny_unknown_fields)]
+    pub struct FieldServerVirtualTls {
+        /// TLS protocol supported
+        #[serde(
+            serialize_with = "crate::parser::tls_protocol_version::serialize",
+            deserialize_with = "crate::parser::tls_protocol_version::deserialize"
+        )]
+        pub protocol_version: Vec<rustls::ProtocolVersion>,
+        /// Certificate chain to use for the TLS connection.
+        pub certificate: TlsFile<rustls::Certificate>,
+        /// Private key to use for the TLS connection.
+        pub private_key: TlsFile<rustls::PrivateKey>,
+        /// Policy of security for the TLS connection.
+        #[serde(default = "FieldServerVirtualTls::default_sender_security_level")]
+        pub sender_security_level: TlsSecurityLevel,
+    }
+
+    /// The policy of security for the TLS connection.
+    #[derive(Debug, Copy, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+    pub enum TlsSecurityLevel {
+        /// Connection **MAY stay in plain text** for theirs transaction
+        ///
+        /// Connection **MAY UPGRADE** at any moment with a TLS tunnel (using STARTTLS mechanism)
+        May,
+        /// Connection **MUST BE UNDER TLS** tunnel (using STARTTLS mechanism or using port 465)
+        Encrypt,
+        /// DANE protocol using TLSA dns records to establish a secure connection with a distant server.
+        Dane {
+            /// port
+            port: u16,
+        },
+    }
+
+    #[doc(hidden)]
+    #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+    #[serde(transparent)]
+    pub struct TlsFile<T> {
+        #[serde(skip_serializing)]
+        pub inner: T,
+        pub path: std::path::PathBuf,
+    }
+
+    /// The TLS parameter for the **INCOMING SIDE** of the server (common with the virtual entry).
+    // TODO: should use [`FieldServerVirtualTls`] flattened ?
+    #[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+    #[serde(deny_unknown_fields)]
+    pub struct FieldServerTls {
+        /// Policy of security for the TLS connection.
+        pub security_level: TlsSecurityLevel,
+        /// Ignore the client’s ciphersuite order.
+        /// Instead, choose the top ciphersuite in the server list which is supported by the client.
+        pub preempt_cipherlist: bool,
+        /// Timeout for the TLS handshake. Sending a [`CodeID::Timeout`] to the client.
+        #[serde(with = "humantime_serde")]
+        pub handshake_timeout: std::time::Duration,
+        /// TLS protocol supported
+        #[serde(
+            serialize_with = "crate::parser::tls_protocol_version::serialize",
+            deserialize_with = "crate::parser::tls_protocol_version::deserialize"
+        )]
+        pub protocol_version: Vec<rustls::ProtocolVersion>,
+        #[serde(
+            serialize_with = "crate::parser::tls_cipher_suite::serialize",
+            deserialize_with = "crate::parser::tls_cipher_suite::deserialize",
+            default = "FieldServerTls::default_cipher_suite"
+        )]
+        /// TLS cipher suite supported
+        pub cipher_suite: Vec<rustls::CipherSuite>,
+        /// Certificate chain to use for the TLS connection.
+        pub certificate: TlsFile<rustls::Certificate>,
+        /// Private key to use for the TLS connection.
+        pub private_key: TlsFile<rustls::PrivateKey>,
+    }
+
+    /// Configuration of the client's error handling.
+    #[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+    #[serde(deny_unknown_fields)]
+    pub struct FieldServerSMTPError {
+        /// The maximum number of errors before the client is delay between each response.
+        ///
+        /// `-1` to disable
+        pub soft_count: i64,
+        /// The maximum number of errors before the client is disconnected.
+        ///
+        /// `-1` to disable
+        pub hard_count: i64,
+        /// The delay used between each response, after `soft_count` errors.
+        /// Unused if `soft_count` is `-1`.
+        #[serde(with = "humantime_serde")]
+        pub delay: std::time::Duration,
+    }
+
+    /// Configuration of the receiver timeout between each message.
+    #[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+    #[serde(deny_unknown_fields)]
+    pub struct FieldServerSMTPTimeoutClient {
+        /// Delay between the connection and the first `HELO/EHLO`
+        #[serde(with = "humantime_serde")]
+        pub connect: std::time::Duration,
+        /// Delay between the last `HELO/EHLO` and the next `MAIL FROM`
+        #[serde(with = "humantime_serde")]
+        pub helo: std::time::Duration,
+        /// Delay between the last `MAIL FROM` and the next `RCPT TO`
+        #[serde(with = "humantime_serde")]
+        pub mail_from: std::time::Duration,
+        /// Delay between the last `RCPT TO` and the next `DATA`
+        #[serde(with = "humantime_serde")]
+        pub rcpt_to: std::time::Duration,
+        /// Delay between each message after the `DATA` command.
+        #[serde(with = "humantime_serde")]
+        pub data: std::time::Duration,
+    }
+
+    /// Policy of the extension AUTH.
+    #[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+    #[serde(deny_unknown_fields)]
+    pub struct FieldServerSMTPAuth {
+        /// If `true`, the server will reject `MAIL FROM` commands if the client is not authenticated,
+        /// sending [`CodeID::AuthRequired`]
+        #[serde(default = "FieldServerSMTPAuth::default_must_be_authenticated")]
+        pub must_be_authenticated: bool,
+        /// Some mechanisms are considered unsecure under non-TLS connections.
+        /// If `false`, the server will allow to use them even on clair connections.
+        ///
+        /// `false` by default.
+        #[serde(default = "FieldServerSMTPAuth::default_enable_dangerous_mechanism_in_clair")]
+        pub enable_dangerous_mechanism_in_clair: bool,
+        /// List of mechanisms supported by the server.
+        #[serde(default = "FieldServerSMTPAuth::default_mechanisms")]
+        pub mechanisms: Vec<Mechanism>,
+        /// If the AUTH exchange is canceled, the server will not consider the connection as closing,
+        /// increasing the number of attempt failed, until `attempt_count_max`, producing an error.
+        #[serde(default = "FieldServerSMTPAuth::default_attempt_count_max")]
+        pub attempt_count_max: i64,
+    }
+
+    /// Parameters of the SMTP.
+    #[serde_as]
+    #[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+    #[serde(deny_unknown_fields)]
+    pub struct FieldServerSMTP {
+        /// Maximum number of recipients received in the envelop, extra recipient will produce an [`CodeID::TooManyRecipients`].
+        #[serde(default = "FieldServerSMTP::default_rcpt_count_max")]
+        pub rcpt_count_max: usize,
+        /// Disable the `EHLO` keywords, and thus the SMTP extension.
+        ///
+        /// default: `false`
+        #[serde(default = "FieldServerSMTP::default_disable_ehlo")]
+        pub disable_ehlo: bool,
+        /// List of extension required to run the server, producing an error if not supported.
+        ///
+        /// UNUSED
+        // TODO: parse extension enum
+        #[serde(default = "FieldServerSMTP::default_required_extension")]
+        pub required_extension: Vec<String>,
+        /// SMTP's error policy.
+        #[serde(default)]
+        pub error: FieldServerSMTPError,
+        /// SMTP's timeout policy.
+        #[serde(default)]
+        pub timeout_client: FieldServerSMTPTimeoutClient,
+        /// Dictionary of the reply sent by the server during the SMTP transaction.
+        #[serde(default)]
+        #[serde_as(as = "std::collections::BTreeMap<serde_with::DisplayFromStr, _>")]
+        pub codes: std::collections::BTreeMap<CodeID, Reply>,
+        /// SMTP's authentication policy.
+        pub auth: Option<FieldServerSMTPAuth>,
+    }
+
+    /// Configuration of the DNS resolver.
+    #[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+    #[allow(clippy::large_enum_variant)]
+    #[serde(tag = "type", deny_unknown_fields)]
+    pub enum FieldServerDNS {
+        /// Using the resolver of the system (/etc/resolv.conf).
+        #[serde(rename = "system")]
+        System,
+        /// Using the google DNS resolver.
+        #[serde(rename = "google")]
+        Google {
+            /// Parameters
+            #[serde(default)]
+            options: ResolverOptsWrapper,
+        },
+        /// Using the google DNS resolver.
+        #[serde(rename = "cloudflare")]
+        CloudFlare {
+            /// Parameters
+            #[serde(default)]
+            options: ResolverOptsWrapper,
+        },
+        /// A custom resolver.
+        #[serde(rename = "custom")]
+        Custom {
+            /// Configuration of the resolver.
+            config: trust_dns_resolver::config::ResolverConfig,
+            /// Parameters
+            #[serde(default)]
+            options: ResolverOptsWrapper,
+        },
+    }
+
+    /// Parameter for the DNS resolver.
+    // TODO: remove that and use serde_with
+    #[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+    #[allow(clippy::struct_excessive_bools)]
+    pub struct ResolverOptsWrapper {
+        /// Specify the timeout for a request. Defaults to 5 seconds
+        #[serde(with = "humantime_serde")]
+        #[serde(default = "ResolverOptsWrapper::default_timeout")]
+        pub timeout: std::time::Duration,
+        /// Number of retries after lookup failure before giving up. Defaults to 2
+        #[serde(default = "ResolverOptsWrapper::default_attempts")]
+        pub attempts: usize,
+        /// Rotate through the resource records in the response (if there is more than one for a given name)
+        #[serde(default = "ResolverOptsWrapper::default_rotate")]
+        pub rotate: bool,
+        /// Use DNSSec to validate the request
+        #[serde(default = "ResolverOptsWrapper::default_dnssec")]
+        pub dnssec: bool,
+        /// The ip_strategy for the Resolver to use when lookup Ipv4 or Ipv6 addresses
+        #[serde(default = "ResolverOptsWrapper::default_ip_strategy")]
+        pub ip_strategy: trust_dns_resolver::config::LookupIpStrategy,
+        /// Cache size is in number of records (some records can be large)
+        #[serde(default = "ResolverOptsWrapper::default_cache_size")]
+        pub cache_size: usize,
+        /// Check /ect/hosts file before dns requery (only works for unix like OS)
+        #[serde(default = "ResolverOptsWrapper::default_use_hosts_file")]
+        pub use_hosts_file: bool,
+        /// Number of concurrent requests per query
+        ///
+        /// Where more than one nameserver is configured, this configures the resolver to send queries
+        /// to a number of servers in parallel. Defaults to 2; 0 or 1 will execute requests serially.
+        #[serde(default = "ResolverOptsWrapper::default_num_concurrent_reqs")]
+        pub num_concurrent_reqs: usize,
+    }
+
+    /// Configuration of the application run by `vSMTP`.
+    #[derive(Default, Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+    #[serde(deny_unknown_fields)]
+    pub struct FieldAppVSL {
+        /// Entry point of the vsl application.
+        pub filepath: Option<std::path::PathBuf>,
+    }
+
+    /// Application's parameter of the logs, same properties than [`FieldServerLogs`].
+    #[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+    #[serde(deny_unknown_fields)]
+    pub struct FieldAppLogs {
+        ///
+        #[serde(default = "FieldAppLogs::default_filepath")]
+        pub filepath: std::path::PathBuf,
+        ///
+        #[serde(default = "FieldAppLogs::default_level")]
+        pub level: log::LevelFilter,
+        ///
+        #[serde(default = "FieldAppLogs::default_format")]
+        pub format: String,
+        ///
+        #[serde(default = "FieldAppLogs::default_size_limit")]
+        pub size_limit: u64,
+        ///
+        #[serde(default = "FieldAppLogs::default_archive_count")]
+        pub archive_count: u32,
+    }
+
+    /// Configuration of the application run by `vSMTP`.
+    #[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+    #[serde(deny_unknown_fields)]
+    pub struct FieldApp {
+        /// Folder under which artifact will be stored.
+        #[serde(default = "FieldApp::default_dirpath")]
+        pub dirpath: std::path::PathBuf,
+        /// see [`FieldAppVSL`]
+        #[serde(default)]
+        pub vsl: FieldAppVSL,
+        /// see [`FieldAppLogs`]
+        #[serde(default)]
+        pub logs: FieldAppLogs,
+    }
 }

--- a/src/vsmtp/vsmtp-config/src/default.rs
+++ b/src/vsmtp/vsmtp-config/src/default.rs
@@ -14,13 +14,12 @@
  * this program. If not, see https://www.gnu.org/licenses/.
  *
 */
-#![allow(clippy::module_name_repetitions)]
 
 use crate::config::{
-    Config, ConfigApp, ConfigAppLogs, ConfigAppVSL, ConfigQueueDelivery, ConfigQueueWorking,
-    ConfigServer, ConfigServerDNS, ConfigServerInterfaces, ConfigServerLogs, ConfigServerQueues,
-    ConfigServerSMTP, ConfigServerSMTPAuth, ConfigServerSMTPError, ConfigServerSMTPTimeoutClient,
-    ConfigServerSystem, ConfigServerSystemThreadPool, ConfigServerTls, ConfigServerVirtualTls,
+    Config, FieldApp, FieldAppLogs, FieldAppVSL, FieldQueueDelivery, FieldQueueWorking,
+    FieldServer, FieldServerDNS, FieldServerInterfaces, FieldServerLogs, FieldServerQueues,
+    FieldServerSMTP, FieldServerSMTPAuth, FieldServerSMTPError, FieldServerSMTPTimeoutClient,
+    FieldServerSystem, FieldServerSystemThreadPool, FieldServerTls, FieldServerVirtualTls,
     ResolverOptsWrapper, TlsSecurityLevel,
 };
 use vsmtp_common::{
@@ -34,31 +33,31 @@ impl Default for Config {
     fn default() -> Self {
         Self::ensure(Self {
             version_requirement: semver::VersionReq::parse(">=1.0.0").unwrap(),
-            server: ConfigServer::default(),
-            app: ConfigApp::default(),
+            server: FieldServer::default(),
+            app: FieldApp::default(),
         })
         .unwrap()
     }
 }
 
-impl Default for ConfigServer {
+impl Default for FieldServer {
     fn default() -> Self {
         Self {
             domain: Self::hostname(),
             client_count_max: Self::default_client_count_max(),
-            system: ConfigServerSystem::default(),
-            interfaces: ConfigServerInterfaces::default(),
-            logs: ConfigServerLogs::default(),
-            queues: ConfigServerQueues::default(),
+            system: FieldServerSystem::default(),
+            interfaces: FieldServerInterfaces::default(),
+            logs: FieldServerLogs::default(),
+            queues: FieldServerQueues::default(),
             tls: None,
-            smtp: ConfigServerSMTP::default(),
-            dns: ConfigServerDNS::default(),
+            smtp: FieldServerSMTP::default(),
+            dns: FieldServerDNS::default(),
             r#virtual: std::collections::BTreeMap::default(),
         }
     }
 }
 
-impl ConfigServer {
+impl FieldServer {
     pub(crate) fn hostname() -> String {
         hostname::get().unwrap().to_str().unwrap().to_string()
     }
@@ -68,18 +67,18 @@ impl ConfigServer {
     }
 }
 
-impl Default for ConfigServerSystem {
+impl Default for FieldServerSystem {
     fn default() -> Self {
         Self {
             user: Self::default_user(),
             group: Self::default_group(),
             group_local: None,
-            thread_pool: ConfigServerSystemThreadPool::default(),
+            thread_pool: FieldServerSystemThreadPool::default(),
         }
     }
 }
 
-impl ConfigServerSystem {
+impl FieldServerSystem {
     pub(crate) fn default_user() -> users::User {
         users::get_user_by_name(match option_env!("CI") {
             Some(_) => "root",
@@ -97,7 +96,7 @@ impl ConfigServerSystem {
     }
 }
 
-impl Default for ConfigServerSystemThreadPool {
+impl Default for FieldServerSystemThreadPool {
     fn default() -> Self {
         Self {
             receiver: Self::default_receiver(),
@@ -107,7 +106,7 @@ impl Default for ConfigServerSystemThreadPool {
     }
 }
 
-impl ConfigServerSystemThreadPool {
+impl FieldServerSystemThreadPool {
     pub(crate) const fn default_receiver() -> usize {
         6
     }
@@ -121,13 +120,13 @@ impl ConfigServerSystemThreadPool {
     }
 }
 
-impl Default for ConfigServerInterfaces {
+impl Default for FieldServerInterfaces {
     fn default() -> Self {
         Self::ipv4_localhost()
     }
 }
 
-impl ConfigServerInterfaces {
+impl FieldServerInterfaces {
     pub(crate) fn ipv4_localhost() -> Self {
         Self {
             addr: vec!["127.0.0.1:25".parse().expect("valid")],
@@ -137,7 +136,7 @@ impl ConfigServerInterfaces {
     }
 }
 
-impl Default for ConfigServerLogs {
+impl Default for FieldServerLogs {
     fn default() -> Self {
         Self {
             filepath: Self::default_filepath(),
@@ -149,7 +148,7 @@ impl Default for ConfigServerLogs {
     }
 }
 
-impl ConfigServerLogs {
+impl FieldServerLogs {
     pub(crate) fn default_filepath() -> std::path::PathBuf {
         "/var/log/vsmtp/vsmtp.log".into()
     }
@@ -173,7 +172,7 @@ impl ConfigServerLogs {
     }
 }
 
-impl ConfigServerTls {
+impl FieldServerTls {
     pub(crate) fn default_cipher_suite() -> Vec<rustls::CipherSuite> {
         vec![
             // TLS1.3 suites
@@ -191,23 +190,23 @@ impl ConfigServerTls {
     }
 }
 
-impl Default for ConfigServerQueues {
+impl Default for FieldServerQueues {
     fn default() -> Self {
         Self {
             dirpath: Self::default_dirpath(),
-            working: ConfigQueueWorking::default(),
-            delivery: ConfigQueueDelivery::default(),
+            working: FieldQueueWorking::default(),
+            delivery: FieldQueueDelivery::default(),
         }
     }
 }
 
-impl ConfigServerQueues {
+impl FieldServerQueues {
     pub(crate) fn default_dirpath() -> std::path::PathBuf {
         "/var/spool/vsmtp".into()
     }
 }
 
-impl Default for ConfigQueueWorking {
+impl Default for FieldQueueWorking {
     fn default() -> Self {
         Self {
             channel_size: Self::default_channel_size(),
@@ -215,13 +214,13 @@ impl Default for ConfigQueueWorking {
     }
 }
 
-impl ConfigQueueWorking {
+impl FieldQueueWorking {
     pub(crate) const fn default_channel_size() -> usize {
         32
     }
 }
 
-impl Default for ConfigQueueDelivery {
+impl Default for FieldQueueDelivery {
     fn default() -> Self {
         Self {
             channel_size: Self::default_channel_size(),
@@ -231,7 +230,7 @@ impl Default for ConfigQueueDelivery {
     }
 }
 
-impl ConfigQueueDelivery {
+impl FieldQueueDelivery {
     pub(crate) const fn default_channel_size() -> usize {
         32
     }
@@ -245,13 +244,13 @@ impl ConfigQueueDelivery {
     }
 }
 
-impl ConfigServerVirtualTls {
+impl FieldServerVirtualTls {
     pub(crate) const fn default_sender_security_level() -> TlsSecurityLevel {
         TlsSecurityLevel::Encrypt
     }
 }
 
-impl Default for ConfigServerSMTPAuth {
+impl Default for FieldServerSMTPAuth {
     fn default() -> Self {
         Self {
             enable_dangerous_mechanism_in_clair: Self::default_enable_dangerous_mechanism_in_clair(
@@ -263,7 +262,7 @@ impl Default for ConfigServerSMTPAuth {
     }
 }
 
-impl ConfigServerSMTPAuth {
+impl FieldServerSMTPAuth {
     pub(crate) const fn default_enable_dangerous_mechanism_in_clair() -> bool {
         false
     }
@@ -283,21 +282,21 @@ impl ConfigServerSMTPAuth {
     }
 }
 
-impl Default for ConfigServerSMTP {
+impl Default for FieldServerSMTP {
     fn default() -> Self {
         Self {
             rcpt_count_max: Self::default_rcpt_count_max(),
             disable_ehlo: Self::default_disable_ehlo(),
             required_extension: Self::default_required_extension(),
-            error: ConfigServerSMTPError::default(),
-            timeout_client: ConfigServerSMTPTimeoutClient::default(),
+            error: FieldServerSMTPError::default(),
+            timeout_client: FieldServerSMTPTimeoutClient::default(),
             codes: Self::default_smtp_codes(),
             auth: None,
         }
     }
 }
 
-impl ConfigServerSMTP {
+impl FieldServerSMTP {
     pub(crate) const fn default_rcpt_count_max() -> usize {
         1000
     }
@@ -420,7 +419,7 @@ impl ConfigServerSMTP {
     }
 }
 
-impl Default for ConfigServerDNS {
+impl Default for FieldServerDNS {
     fn default() -> Self {
         Self::System
     }
@@ -474,7 +473,7 @@ impl ResolverOptsWrapper {
     }
 }
 
-impl Default for ConfigServerSMTPError {
+impl Default for FieldServerSMTPError {
     fn default() -> Self {
         Self {
             soft_count: 10,
@@ -484,7 +483,7 @@ impl Default for ConfigServerSMTPError {
     }
 }
 
-impl Default for ConfigServerSMTPTimeoutClient {
+impl Default for FieldServerSMTPTimeoutClient {
     fn default() -> Self {
         Self {
             connect: std::time::Duration::from_secs(5 * 60),
@@ -496,23 +495,23 @@ impl Default for ConfigServerSMTPTimeoutClient {
     }
 }
 
-impl Default for ConfigApp {
+impl Default for FieldApp {
     fn default() -> Self {
         Self {
             dirpath: Self::default_dirpath(),
-            vsl: ConfigAppVSL::default(),
-            logs: ConfigAppLogs::default(),
+            vsl: FieldAppVSL::default(),
+            logs: FieldAppLogs::default(),
         }
     }
 }
 
-impl ConfigApp {
+impl FieldApp {
     pub(crate) fn default_dirpath() -> std::path::PathBuf {
         "/var/spool/vsmtp/app".into()
     }
 }
 
-impl Default for ConfigAppLogs {
+impl Default for FieldAppLogs {
     fn default() -> Self {
         Self {
             filepath: Self::default_filepath(),
@@ -524,7 +523,7 @@ impl Default for ConfigAppLogs {
     }
 }
 
-impl ConfigAppLogs {
+impl FieldAppLogs {
     pub(crate) fn default_filepath() -> std::path::PathBuf {
         "/var/log/vsmtp/app.log".into()
     }

--- a/src/vsmtp/vsmtp-config/src/default.rs
+++ b/src/vsmtp/vsmtp-config/src/default.rs
@@ -15,7 +15,7 @@
  *
 */
 
-use crate::config::{
+use crate::config::field::{
     Config, FieldApp, FieldAppLogs, FieldAppVSL, FieldQueueDelivery, FieldQueueWorking,
     FieldServer, FieldServerDNS, FieldServerInterfaces, FieldServerLogs, FieldServerQueues,
     FieldServerSMTP, FieldServerSMTPAuth, FieldServerSMTPError, FieldServerSMTPTimeoutClient,
@@ -312,6 +312,7 @@ impl FieldServerSMTP {
             .collect()
     }
 
+    // TODO: should be const and compile time checked
     pub(crate) fn default_smtp_codes() -> std::collections::BTreeMap<CodeID, Reply> {
         let codes: std::collections::BTreeMap<CodeID, Reply> = collection! {
             CodeID::Greetings => Reply::new(

--- a/src/vsmtp/vsmtp-config/src/ensure.rs
+++ b/src/vsmtp/vsmtp-config/src/ensure.rs
@@ -1,0 +1,122 @@
+/*
+ * vSMTP mail transfer agent
+ * Copyright (C) 2022 viridIT SAS
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see https://www.gnu.org/licenses/.
+ *
+*/
+use crate::{config::field::FieldServerSMTP, Config};
+use vsmtp_common::{
+    auth::Mechanism,
+    re::{anyhow, strum},
+    CodeID, Reply, ReplyCode,
+};
+
+fn mech_list_to_code(list: &[Mechanism]) -> String {
+    format!(
+        "AUTH {}\r\n",
+        list.iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+            .join(" ")
+    )
+}
+
+impl Config {
+    pub(crate) fn ensure(mut config: Self) -> anyhow::Result<Self> {
+        anyhow::ensure!(
+            config.app.logs.filepath != config.server.logs.filepath,
+            "System and Application logs cannot both be written in '{}' !",
+            config.app.logs.filepath.display()
+        );
+
+        anyhow::ensure!(
+            config.server.system.thread_pool.processing != 0
+                && config.server.system.thread_pool.receiver != 0
+                && config.server.system.thread_pool.delivery != 0,
+            "Worker threads cannot be set to 0"
+        );
+
+        {
+            let auth_mechanism_list: Option<(Vec<Mechanism>, Vec<Mechanism>)> = config
+                .server
+                .smtp
+                .auth
+                .as_ref()
+                .map(|auth| auth.mechanisms.iter().partition(|m| m.must_be_under_tls()));
+
+            config.server.smtp.codes.insert(
+                CodeID::EhloPain,
+                Reply::new(
+                    ReplyCode::Code { code: 250 },
+                    [
+                        &config.server.domain,
+                        "\r\n",
+                        &auth_mechanism_list
+                            .as_ref()
+                            .map(|(plain, secured)| {
+                                if config
+                                    .server
+                                    .smtp
+                                    .auth
+                                    .as_ref()
+                                    .map_or(false, |auth| auth.enable_dangerous_mechanism_in_clair)
+                                {
+                                    mech_list_to_code(&[secured.clone(), plain.clone()].concat())
+                                } else {
+                                    mech_list_to_code(secured)
+                                }
+                            })
+                            .unwrap_or_default(),
+                        "STARTTLS\r\n",
+                        "8BITMIME\r\n",
+                        "SMTPUTF8\r\n",
+                    ]
+                    .concat(),
+                ),
+            );
+
+            config.server.smtp.codes.insert(
+                CodeID::EhloSecured,
+                Reply::new(
+                    ReplyCode::Code { code: 250 },
+                    [
+                        &config.server.domain,
+                        "\r\n",
+                        &auth_mechanism_list
+                            .as_ref()
+                            .map(|(must_be_secured, _)| mech_list_to_code(must_be_secured))
+                            .unwrap_or_default(),
+                        "8BITMIME\r\n",
+                        "SMTPUTF8\r\n",
+                    ]
+                    .concat(),
+                ),
+            );
+        }
+
+        let default_values = FieldServerSMTP::default_smtp_codes();
+        let reply_codes = &mut config.server.smtp.codes;
+
+        for key in <CodeID as strum::IntoEnumIterator>::iter() {
+            reply_codes
+                .entry(key)
+                .or_insert_with_key(|key| default_values.get(key).expect("missing code").clone());
+
+            reply_codes.entry(key).and_modify(|reply| {
+                reply.set(reply.text().replace("{domain}", &config.server.domain));
+            });
+        }
+
+        Ok(config)
+    }
+}

--- a/src/vsmtp/vsmtp-config/src/lib.rs
+++ b/src/vsmtp/vsmtp-config/src/lib.rs
@@ -1,4 +1,20 @@
 //! vSMTP configuration
+//!
+//! This module contains the configuration for the vSMTP server.
+//!
+//! # Configuration
+//!
+//! The type [`Config`] expose two methods :
+//! * [`Config::builder`] to create a new configuration builder.
+//! * [`Config::from_toml`] to read a configuration from a TOML file.
+//!
+//! # Example
+//!
+//! You can find examples of TOML file at <https://github.com/viridIT/vSMTP/tree/develop/examples/config>
+//!
+//! # Fields
+//!
+//! TODO!
 
 #![doc(html_no_source)]
 #![deny(missing_docs)]
@@ -8,7 +24,6 @@
 #![warn(clippy::pedantic)]
 #![warn(clippy::nursery)]
 #![warn(clippy::cargo)]
-//
 
 /*
  * vSMTP mail transfer agent
@@ -54,20 +69,21 @@ pub mod builder {
     mod wants;
     mod with;
 
-    #[doc(hidden)]
-    pub mod validate;
+    pub(crate) mod validate;
     pub use wants::*;
     pub use with::*;
 }
 
 mod config;
 mod default;
+mod ensure;
 mod log4rs_helper;
 mod rustls_helper;
 mod trust_dns_helper;
 mod virtual_tls;
 
-pub use config::*;
+pub use config::{field, Config};
+
 pub use log4rs_helper::get_log4rs_config;
 pub use rustls_helper::get_rustls_config;
 pub use trust_dns_helper::{build_resolvers, Resolvers};
@@ -86,7 +102,7 @@ use builder::{Builder, WantsVersion};
 use vsmtp_common::{libc_abstraction::chown, re::anyhow};
 
 impl Config {
-    ///
+    /// Create an instance of [`Builder`].
     #[must_use]
     pub const fn builder() -> Builder<WantsVersion> {
         Builder {
@@ -136,11 +152,7 @@ impl Config {
     }
 }
 
-/// create a folder at `[app.dirpath]` if needed, or just create the app folder.
-///
-/// # Errors
-/// * failed to create the app directory.
-/// * failed to set proper rights to the app directory.
+#[doc(hidden)]
 pub fn create_app_folder(
     config: &Config,
     path: Option<&str>,

--- a/src/vsmtp/vsmtp-config/src/lib.rs
+++ b/src/vsmtp/vsmtp-config/src/lib.rs
@@ -9,7 +9,6 @@
 #![warn(clippy::nursery)]
 #![warn(clippy::cargo)]
 //
-#![allow(clippy::doc_markdown)]
 
 /*
  * vSMTP mail transfer agent

--- a/src/vsmtp/vsmtp-config/src/parser/tls_certificate.rs
+++ b/src/vsmtp/vsmtp-config/src/parser/tls_certificate.rs
@@ -82,12 +82,10 @@ where
 
 #[cfg(test)]
 mod tests {
+    use crate::field::TlsFile;
     use std::io::Write;
-
     use vsmtp_common::re::serde_json;
     use vsmtp_test::get_tls_file;
-
-    use crate::TlsFile;
 
     #[derive(Debug, serde::Serialize, serde::Deserialize)]
     struct S {

--- a/src/vsmtp/vsmtp-config/src/parser/tls_private_key.rs
+++ b/src/vsmtp/vsmtp-config/src/parser/tls_private_key.rs
@@ -88,10 +88,9 @@ S: serde::Serializer,
 mod tests {
     use std::io::Write;
 
+    use crate::field::TlsFile;
     use vsmtp_common::re::serde_json;
     use vsmtp_test::get_tls_file;
-
-    use crate::TlsFile;
 
     #[derive(Debug, serde::Serialize, serde::Deserialize)]
     struct S {

--- a/src/vsmtp/vsmtp-config/src/rustls_helper.rs
+++ b/src/vsmtp/vsmtp-config/src/rustls_helper.rs
@@ -17,7 +17,7 @@
 use rustls::ALL_CIPHER_SUITES;
 use vsmtp_common::re::{anyhow, log};
 
-use crate::{config::ConfigServerTls, ConfigServerVirtual};
+use crate::{config::FieldServerTls, FieldServerVirtual};
 
 struct TlsLogger;
 impl rustls::KeyLog for TlsLogger {
@@ -61,8 +61,8 @@ fn to_supported_cipher_suite(
 
 #[doc(hidden)]
 pub fn get_rustls_config(
-    config: &ConfigServerTls,
-    virtual_entries: &std::collections::BTreeMap<String, ConfigServerVirtual>,
+    config: &FieldServerTls,
+    virtual_entries: &std::collections::BTreeMap<String, FieldServerVirtual>,
 ) -> anyhow::Result<rustls::ServerConfig> {
     let protocol_version = match (
         config

--- a/src/vsmtp/vsmtp-config/src/rustls_helper.rs
+++ b/src/vsmtp/vsmtp-config/src/rustls_helper.rs
@@ -17,7 +17,7 @@
 use rustls::ALL_CIPHER_SUITES;
 use vsmtp_common::re::{anyhow, log};
 
-use crate::{config::FieldServerTls, FieldServerVirtual};
+use crate::field::{FieldServerTls, FieldServerVirtual};
 
 struct TlsLogger;
 impl rustls::KeyLog for TlsLogger {

--- a/src/vsmtp/vsmtp-config/src/tests/root_example/secured.rs
+++ b/src/vsmtp/vsmtp-config/src/tests/root_example/secured.rs
@@ -17,7 +17,7 @@
 use vsmtp_common::{collection, state::StateSMTP};
 
 use crate::{
-    config::{ConfigQueueDelivery, ConfigQueueWorking},
+    config::{FieldQueueDelivery, FieldQueueWorking},
     Config,
 };
 
@@ -35,8 +35,8 @@ fn parse() {
             .with_default_logs_settings()
             .with_spool_dir_and_queues(
                 "/var/spool/vsmtp",
-                ConfigQueueWorking { channel_size: 16 },
-                ConfigQueueDelivery {
+                FieldQueueWorking { channel_size: 16 },
+                FieldQueueDelivery {
                     channel_size: 16,
                     deferred_retry_max: 10,
                     deferred_retry_period: std::time::Duration::from_secs(600)

--- a/src/vsmtp/vsmtp-config/src/tests/root_example/secured.rs
+++ b/src/vsmtp/vsmtp-config/src/tests/root_example/secured.rs
@@ -14,12 +14,11 @@
  * this program. If not, see https://www.gnu.org/licenses/.
  *
 */
-use vsmtp_common::{collection, state::StateSMTP};
-
 use crate::{
-    config::{FieldQueueDelivery, FieldQueueWorking},
+    config::field::{FieldQueueDelivery, FieldQueueWorking},
     Config,
 };
+use vsmtp_common::{collection, state::StateSMTP};
 
 #[test]
 fn parse() {
@@ -74,7 +73,7 @@ fn parse() {
 
                     cfg
                 },
-                crate::ResolverOptsWrapper::default()
+                crate::field::ResolverOptsWrapper::default()
             )
             .without_virtual_entries()
             .validate()

--- a/src/vsmtp/vsmtp-config/src/tests/root_example/tls.rs
+++ b/src/vsmtp/vsmtp-config/src/tests/root_example/tls.rs
@@ -14,7 +14,11 @@
  * this program. If not, see https://www.gnu.org/licenses/.
  *
 */
-use crate::{builder::VirtualEntry, Config, FieldServerDNS, ResolverOptsWrapper};
+use crate::{
+    builder::VirtualEntry,
+    field::{FieldServerDNS, ResolverOptsWrapper},
+    Config,
+};
 
 #[test]
 fn parse() {

--- a/src/vsmtp/vsmtp-config/src/tests/root_example/tls.rs
+++ b/src/vsmtp/vsmtp-config/src/tests/root_example/tls.rs
@@ -14,7 +14,7 @@
  * this program. If not, see https://www.gnu.org/licenses/.
  *
 */
-use crate::{builder::VirtualEntry, Config, ConfigServerDNS, ResolverOptsWrapper};
+use crate::{builder::VirtualEntry, Config, FieldServerDNS, ResolverOptsWrapper};
 
 #[test]
 fn parse() {
@@ -52,7 +52,7 @@ fn parse() {
                 VirtualEntry {
                     domain: "testserver2.com".to_string(),
                     tls: None,
-                    dns: Some(ConfigServerDNS::System),
+                    dns: Some(FieldServerDNS::System),
                 },
                 VirtualEntry {
                     domain: "testserver3.com".to_string(),
@@ -68,7 +68,7 @@ fn parse() {
                         "../../../examples/config/tls/certificate.crt".to_string(),
                         "../../../examples/config/tls/private_key.key".to_string()
                     )),
-                    dns: Some(ConfigServerDNS::Google {
+                    dns: Some(FieldServerDNS::Google {
                         options: ResolverOptsWrapper::default()
                     }),
                 },

--- a/src/vsmtp/vsmtp-config/src/trust_dns_helper.rs
+++ b/src/vsmtp/vsmtp-config/src/trust_dns_helper.rs
@@ -14,18 +14,16 @@
  * this program. If not, see https://www.gnu.org/licenses/.
  *
 */
-use crate::{Config, FieldServerDNS, ResolverOptsWrapper};
+use crate::{
+    field::{FieldServerDNS, ResolverOptsWrapper},
+    Config,
+};
 use trust_dns_resolver::{config::ResolverConfig, error::ResolveError, TokioAsyncResolver};
 
-/// dns resolvers filtered by domain. (root & sni)
+#[doc(hidden)]
 pub type Resolvers = std::collections::HashMap<String, TokioAsyncResolver>;
 
-/// construct a [trust-dns] `ResolverOpts` struct from our wrapper.
-///
-/// # Notes
-/// * cannot use the From trait here because `ResolverOpts` is from an external library.
-/// * cannot use struct {} declaration because `ResolverOpts` is non-exhaustive.
-pub fn resolver_opts_from_config(
+fn resolver_opts_from_config(
     config: &ResolverOptsWrapper,
 ) -> trust_dns_resolver::config::ResolverOpts {
     let mut opts = trust_dns_resolver::config::ResolverOpts::default();
@@ -42,10 +40,7 @@ pub fn resolver_opts_from_config(
     opts
 }
 
-/// build the default resolver from the dns config, and one resolver
-/// for each virtual domains.
-///
-/// # Errors
+#[doc(hidden)]
 pub fn build_resolvers(config: &Config) -> Result<Resolvers, ResolveError> {
     let mut resolvers = std::collections::HashMap::<String, TokioAsyncResolver>::with_capacity(
         config.server.r#virtual.len() + 1,
@@ -72,23 +67,17 @@ pub fn build_resolvers(config: &Config) -> Result<Resolvers, ResolveError> {
     Ok(resolvers)
 }
 
-/// build an async dns using `tokio` & `trust_dns` from configuration.
-///
-/// # Errors
-///
-/// * Failed to create the resolver.
 fn build_dns_from_config(config: &FieldServerDNS) -> Result<TokioAsyncResolver, ResolveError> {
     match &config {
-        crate::config::FieldServerDNS::System => TokioAsyncResolver::tokio_from_system_conf(),
-        crate::config::FieldServerDNS::Google { options } => {
+        FieldServerDNS::System => TokioAsyncResolver::tokio_from_system_conf(),
+        FieldServerDNS::Google { options } => {
             TokioAsyncResolver::tokio(ResolverConfig::google(), resolver_opts_from_config(options))
         }
-
-        crate::config::FieldServerDNS::CloudFlare { options } => TokioAsyncResolver::tokio(
+        FieldServerDNS::CloudFlare { options } => TokioAsyncResolver::tokio(
             ResolverConfig::cloudflare(),
             resolver_opts_from_config(options),
         ),
-        crate::config::FieldServerDNS::Custom { config, options } => {
+        FieldServerDNS::Custom { config, options } => {
             TokioAsyncResolver::tokio(config.clone(), resolver_opts_from_config(options))
         }
     }

--- a/src/vsmtp/vsmtp-config/src/trust_dns_helper.rs
+++ b/src/vsmtp/vsmtp-config/src/trust_dns_helper.rs
@@ -14,7 +14,7 @@
  * this program. If not, see https://www.gnu.org/licenses/.
  *
 */
-use crate::{Config, ConfigServerDNS, ResolverOptsWrapper};
+use crate::{Config, FieldServerDNS, ResolverOptsWrapper};
 use trust_dns_resolver::{config::ResolverConfig, error::ResolveError, TokioAsyncResolver};
 
 /// dns resolvers filtered by domain. (root & sni)
@@ -72,23 +72,23 @@ pub fn build_resolvers(config: &Config) -> Result<Resolvers, ResolveError> {
     Ok(resolvers)
 }
 
-/// build an async dns using tokio & trust_dns from configuration.
+/// build an async dns using `tokio` & `trust_dns` from configuration.
 ///
 /// # Errors
 ///
 /// * Failed to create the resolver.
-fn build_dns_from_config(config: &ConfigServerDNS) -> Result<TokioAsyncResolver, ResolveError> {
+fn build_dns_from_config(config: &FieldServerDNS) -> Result<TokioAsyncResolver, ResolveError> {
     match &config {
-        crate::config::ConfigServerDNS::System => TokioAsyncResolver::tokio_from_system_conf(),
-        crate::config::ConfigServerDNS::Google { options } => {
+        crate::config::FieldServerDNS::System => TokioAsyncResolver::tokio_from_system_conf(),
+        crate::config::FieldServerDNS::Google { options } => {
             TokioAsyncResolver::tokio(ResolverConfig::google(), resolver_opts_from_config(options))
         }
 
-        crate::config::ConfigServerDNS::CloudFlare { options } => TokioAsyncResolver::tokio(
+        crate::config::FieldServerDNS::CloudFlare { options } => TokioAsyncResolver::tokio(
             ResolverConfig::cloudflare(),
             resolver_opts_from_config(options),
         ),
-        crate::config::ConfigServerDNS::Custom { config, options } => {
+        crate::config::FieldServerDNS::Custom { config, options } => {
             TokioAsyncResolver::tokio(config.clone(), resolver_opts_from_config(options))
         }
     }

--- a/src/vsmtp/vsmtp-config/src/virtual_tls.rs
+++ b/src/vsmtp/vsmtp-config/src/virtual_tls.rs
@@ -14,12 +14,11 @@
  * this program. If not, see https://www.gnu.org/licenses/.
  *
 */
-use vsmtp_common::re::anyhow;
-
 use crate::{
     parser::{tls_certificate, tls_private_key},
-    ConfigServerVirtualTls, TlsFile,
+    FieldServerDNS, FieldServerVirtual, FieldServerVirtualTls, TlsFile,
 };
+use vsmtp_common::re::anyhow;
 
 impl<'de> serde::Deserialize<'de> for TlsFile<rustls::PrivateKey> {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
@@ -47,7 +46,7 @@ impl<'de> serde::Deserialize<'de> for TlsFile<rustls::Certificate> {
     }
 }
 
-impl ConfigServerVirtualTls {
+impl FieldServerVirtualTls {
     /// create a virtual tls configuration from the certificate & private key paths.
     ///
     /// # Errors
@@ -66,6 +65,60 @@ impl ConfigServerVirtualTls {
                 path: private_key.into(),
             },
             sender_security_level: Self::default_sender_security_level(),
+        })
+    }
+}
+
+impl FieldServerVirtual {
+    /// create a new virtual domain using the root domain parameters.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            tls: None,
+            dns: None,
+        }
+    }
+
+    /// create a new virtual domain with tls parameters.
+    ///
+    /// # Errors
+    ///
+    /// * certificate is not valid
+    /// * private key is not valid
+    pub fn with_tls(certificate: &str, private_key: &str) -> anyhow::Result<Self> {
+        Ok(Self {
+            tls: Some(FieldServerVirtualTls::from_path(certificate, private_key)?),
+            dns: None,
+        })
+    }
+
+    /// create a new virtual domain with a dns config.
+    ///
+    /// # Errors
+    ///
+    /// * certificate is not valid
+    /// * private key is not valid
+    pub const fn with_dns(dns_config: FieldServerDNS) -> anyhow::Result<Self> {
+        Ok(Self {
+            tls: None,
+            dns: Some(dns_config),
+        })
+    }
+
+    /// create a new virtual domain with a dns & tls parameters.
+    ///
+    /// # Errors
+    ///
+    /// * certificate is not valid
+    /// * private key is not valid
+    pub fn with_tls_and_dns(
+        certificate: &str,
+        private_key: &str,
+        dns_config: FieldServerDNS,
+    ) -> anyhow::Result<Self> {
+        Ok(Self {
+            tls: Some(FieldServerVirtualTls::from_path(certificate, private_key)?),
+            dns: Some(dns_config),
         })
     }
 }

--- a/src/vsmtp/vsmtp-config/src/virtual_tls.rs
+++ b/src/vsmtp/vsmtp-config/src/virtual_tls.rs
@@ -15,8 +15,8 @@
  *
 */
 use crate::{
+    field::{FieldServerDNS, FieldServerVirtual, FieldServerVirtualTls, TlsFile},
     parser::{tls_certificate, tls_private_key},
-    FieldServerDNS, FieldServerVirtual, FieldServerVirtualTls, TlsFile,
 };
 use vsmtp_common::re::anyhow;
 

--- a/src/vsmtp/vsmtp-delivery/src/lib.rs
+++ b/src/vsmtp/vsmtp-delivery/src/lib.rs
@@ -25,8 +25,6 @@
 #![warn(clippy::pedantic)]
 #![warn(clippy::nursery)]
 #![warn(clippy::cargo)]
-//
-#![allow(clippy::doc_markdown)]
 
 /// a few helpers to create systems that will deliver emails.
 pub mod transport {

--- a/src/vsmtp/vsmtp-delivery/src/transport/deliver.rs
+++ b/src/vsmtp/vsmtp-delivery/src/transport/deliver.rs
@@ -201,7 +201,7 @@ mod test {
         re::{lettre, tokio},
         transfer::EmailTransferStatus,
     };
-    use vsmtp_config::{Config, ConfigServerDNS};
+    use vsmtp_config::{Config, FieldServerDNS};
 
     #[test]
     fn test_update_rcpt_held_back() {
@@ -233,7 +233,7 @@ mod test {
     async fn test_get_mx_records() {
         // FIXME: find a way to guarantee that the mx records exists.
         let mut config = Config::default();
-        config.server.dns = ConfigServerDNS::System;
+        config.server.dns = FieldServerDNS::System;
         let resolvers = vsmtp_config::build_resolvers(&config).unwrap();
         let dns = resolvers.get(&config.server.domain).unwrap();
 

--- a/src/vsmtp/vsmtp-delivery/src/transport/deliver.rs
+++ b/src/vsmtp/vsmtp-delivery/src/transport/deliver.rs
@@ -201,7 +201,7 @@ mod test {
         re::{lettre, tokio},
         transfer::EmailTransferStatus,
     };
-    use vsmtp_config::{Config, FieldServerDNS};
+    use vsmtp_config::{field::FieldServerDNS, Config};
 
     #[test]
     fn test_update_rcpt_held_back() {

--- a/src/vsmtp/vsmtp-mail-parser/src/helpers.rs
+++ b/src/vsmtp/vsmtp-mail-parser/src/helpers.rs
@@ -22,7 +22,7 @@ pub(super) fn has_wsc(input: &str) -> bool {
     input.starts_with(|c| c == ' ' || c == '\t')
 }
 
-/// See https://datatracker.ietf.org/doc/html/rfc5322#page-11
+/// See <https://datatracker.ietf.org/doc/html/rfc5322#page-11>
 pub(super) fn remove_comments(line: &str) -> anyhow::Result<String> {
     let (depth, is_escaped, output) = line.chars().into_iter().fold(
         (0, false, String::with_capacity(line.len())),
@@ -53,8 +53,8 @@ pub(super) fn remove_comments(line: &str) -> anyhow::Result<String> {
 /// if no content-type header is found, will check the parent for a default
 /// content-type header value.
 ///
-/// see https://datatracker.ietf.org/doc/html/rfc2045#page-14 for default content-type.
-/// see https://datatracker.ietf.org/doc/html/rfc2046#page-26 for digest multipart parent.
+/// see <https://datatracker.ietf.org/doc/html/rfc2045#page-14> for default content-type.
+/// see <https://datatracker.ietf.org/doc/html/rfc2046#page-26> for digest multipart parent.
 pub(super) fn get_mime_type<'a>(
     headers: &'a [MimeHeader],
     parent: Option<&'a [MimeHeader]>,

--- a/src/vsmtp/vsmtp-mail-parser/src/lib.rs
+++ b/src/vsmtp/vsmtp-mail-parser/src/lib.rs
@@ -8,8 +8,6 @@
 #![warn(clippy::pedantic)]
 #![warn(clippy::nursery)]
 #![warn(clippy::cargo)]
-//
-#![allow(clippy::doc_markdown)]
 
 /*
  * vSMTP mail transfer agent

--- a/src/vsmtp/vsmtp-mail-parser/src/parser.rs
+++ b/src/vsmtp/vsmtp-mail-parser/src/parser.rs
@@ -26,7 +26,6 @@ use vsmtp_common::MailParser;
 use vsmtp_common::{BodyType, Mail, MailHeaders};
 use vsmtp_common::{Mime, MimeBodyType, MimeHeader, MimeMultipart};
 
-/// BoundaryType
 /// a boundary serves as a delimiter between mime parts in a multipart section.
 enum BoundaryType {
     Delimiter,
@@ -464,17 +463,12 @@ fn check_mandatory_headers(headers: &[(String, String)]) -> ParserResult<()> {
 }
 
 /// take the name and value of a header and parses those to create
-/// a MimeHeader struct.
+/// a `MimeHeader` struct.
 ///
 /// # Arguments
 ///
 /// * `name` - the name of the header.
 /// * `value` - the value of the header (with all params, folded included if any).
-///
-/// # Return
-///
-/// * `Result<MimeHeader>` - a MimeHeader or a ParserError.
-///
 fn get_mime_header(name: &str, value: &str) -> MimeHeader {
     // cut the current line using the ";" separator into a vector of "arg=value" strings.
     let args = value.split(';').collect::<Vec<&str>>();

--- a/src/vsmtp/vsmtp-rule-engine/src/dsl/object/parsing.rs
+++ b/src/vsmtp/vsmtp-rule-engine/src/dsl/object/parsing.rs
@@ -17,10 +17,11 @@
 use super::Object;
 use crate::error::CompilationError;
 use crate::modules::EngineResult;
+
 /// check of a "object" expression is valid.
 /// the syntax is:
-///   object $name$ $type[:file_type]$ = #{ value: "...", ... };
-///   object $name$ $type[:file_type]$ = "...";
+///   `object $name$ $type[:file_type]$ = #{ value: "...", ... };`
+///   `object $name$ $type[:file_type]$ = "...";`
 pub fn parse_object(
     symbols: &[rhai::ImmutableString],
     look_ahead: &str,

--- a/src/vsmtp/vsmtp-rule-engine/src/dsl/service/mod.rs
+++ b/src/vsmtp/vsmtp-rule-engine/src/dsl/service/mod.rs
@@ -78,7 +78,7 @@ impl std::fmt::Display for Service {
 }
 
 /// a transport using the smtp protocol.
-/// (mostly a new type over lettre::SmtpTransport to implement debug
+/// (mostly a new type over `lettre::SmtpTransport` to implement debug
 /// and make switching transport easy if needed)
 pub struct SmtpConnection(pub lettre::SmtpTransport);
 

--- a/src/vsmtp/vsmtp-rule-engine/src/dsl/service/smtp.rs
+++ b/src/vsmtp/vsmtp-rule-engine/src/dsl/service/smtp.rs
@@ -29,7 +29,7 @@ pub fn parse_smtp_service(
     input: &[rhai::Expression],
     service_name: &str,
 ) -> EngineResult<Service> {
-    /// extract a value from a rhai::Map, optionally inserting a default value.
+    /// extract a value from a `rhai::Map`, optionally inserting a default value.
     fn get_or_default<T: Clone + Send + Sync + 'static>(
         map_name: &str,
         map: &rhai::Map,

--- a/src/vsmtp/vsmtp-rule-engine/src/lib.rs
+++ b/src/vsmtp/vsmtp-rule-engine/src/lib.rs
@@ -8,8 +8,6 @@
 #![warn(clippy::pedantic)]
 #![warn(clippy::nursery)]
 #![warn(clippy::cargo)]
-//
-#![allow(clippy::doc_markdown)]
 
 mod log_channels {
     /// server's rule

--- a/src/vsmtp/vsmtp-rule-engine/src/rule_state.rs
+++ b/src/vsmtp/vsmtp-rule-engine/src/rule_state.rs
@@ -117,7 +117,7 @@ impl RuleState {
         state
     }
 
-    /// create a RuleState from an existing mail context (f.e. when deserializing a context)
+    /// create a `RuleState` from an existing mail context (f.e. when deserializing a context)
     #[must_use]
     pub fn with_context(
         config: &Config,

--- a/src/vsmtp/vsmtp-rule-engine/src/tests/actions.rs
+++ b/src/vsmtp/vsmtp-rule-engine/src/tests/actions.rs
@@ -14,11 +14,10 @@
  * this program. If not, see https://www.gnu.org/licenses/.
  *
 */
-use std::str::FromStr;
-
 use crate::rule_state::RuleState;
 use crate::tests::helpers::get_default_config;
 use crate::{rule_engine::RuleEngine, tests::helpers::get_default_state};
+use std::str::FromStr;
 use vsmtp_common::auth::Mechanism;
 use vsmtp_common::re::serde_json;
 use vsmtp_common::transfer::ForwardTarget;
@@ -30,7 +29,7 @@ use vsmtp_common::{
     Mail,
 };
 use vsmtp_common::{BodyType, CodeID, ReplyOrCodeID};
-use vsmtp_config::FieldServerVirtual;
+use vsmtp_config::field::FieldServerVirtual;
 
 #[test]
 fn test_logs() {

--- a/src/vsmtp/vsmtp-rule-engine/src/tests/actions.rs
+++ b/src/vsmtp/vsmtp-rule-engine/src/tests/actions.rs
@@ -30,7 +30,7 @@ use vsmtp_common::{
     Mail,
 };
 use vsmtp_common::{BodyType, CodeID, ReplyOrCodeID};
-use vsmtp_config::ConfigServerVirtual;
+use vsmtp_config::FieldServerVirtual;
 
 #[test]
 fn test_logs() {
@@ -452,9 +452,9 @@ fn test_in_domain_and_server_name() {
 fn test_in_domain_and_server_name_sni() {
     let mut config = get_default_config("./tmp/app");
     config.server.r#virtual = std::collections::BTreeMap::from_iter([
-        ("example.com".to_string(), ConfigServerVirtual::new()),
-        ("doe.com".to_string(), ConfigServerVirtual::new()),
-        ("green.com".to_string(), ConfigServerVirtual::new()),
+        ("example.com".to_string(), FieldServerVirtual::new()),
+        ("doe.com".to_string(), FieldServerVirtual::new()),
+        ("green.com".to_string(), FieldServerVirtual::new()),
     ]);
 
     let re = RuleEngine::new(&config, &Some(root_example!["actions/utils.vsl"])).unwrap();

--- a/src/vsmtp/vsmtp-rule-engine/src/tests/types/mod.rs
+++ b/src/vsmtp/vsmtp-rule-engine/src/tests/types/mod.rs
@@ -18,7 +18,7 @@ use crate::{rule_engine::RuleEngine, rule_state::RuleState, tests::helpers::get_
 use vsmtp_common::{
     addr, mail_context::MessageBody, state::StateSMTP, status::Status, CodeID, ReplyOrCodeID,
 };
-use vsmtp_config::{builder::VirtualEntry, Config, FieldServerDNS};
+use vsmtp_config::{builder::VirtualEntry, field::FieldServerDNS, Config};
 
 #[test]
 fn test_status() {

--- a/src/vsmtp/vsmtp-rule-engine/src/tests/types/mod.rs
+++ b/src/vsmtp/vsmtp-rule-engine/src/tests/types/mod.rs
@@ -18,7 +18,7 @@ use crate::{rule_engine::RuleEngine, rule_state::RuleState, tests::helpers::get_
 use vsmtp_common::{
     addr, mail_context::MessageBody, state::StateSMTP, status::Status, CodeID, ReplyOrCodeID,
 };
-use vsmtp_config::{builder::VirtualEntry, Config, ConfigServerDNS};
+use vsmtp_config::{builder::VirtualEntry, Config, FieldServerDNS};
 
 #[test]
 fn test_status() {
@@ -165,7 +165,7 @@ fn test_config_display() {
                     .unwrap()
                     .to_string(),
             )),
-            dns: Some(ConfigServerDNS::System),
+            dns: Some(FieldServerDNS::System),
         }])
         .unwrap()
         .validate()

--- a/src/vsmtp/vsmtp-server/src/delivery/mod.rs
+++ b/src/vsmtp/vsmtp-server/src/delivery/mod.rs
@@ -98,8 +98,8 @@ pub async fn start(
 }
 
 /// send the email following each recipient transport method.
-/// return a list of recipients with updated email_status field.
-/// recipients tagged with the Sent email_status are discarded.
+/// return a list of recipients with updated `email_status` field.
+/// recipients tagged with the Sent `email_status` are discarded.
 async fn send_email(
     config: &Config,
     resolvers: &std::collections::HashMap<String, TokioAsyncResolver>,
@@ -182,7 +182,7 @@ fn move_to_queue(config: &Config, ctx: &MailContext) -> anyhow::Result<()> {
 }
 
 /// prepend trace informations to headers.
-/// see https://datatracker.ietf.org/doc/html/rfc5321#section-4.4
+/// see <https://datatracker.ietf.org/doc/html/rfc5321#section-4.4>
 fn add_trace_information(
     config: &Config,
     ctx: &mut MailContext,

--- a/src/vsmtp/vsmtp-server/src/lib.rs
+++ b/src/vsmtp/vsmtp-server/src/lib.rs
@@ -37,7 +37,7 @@ pub use receiver::MailHandler;
 /// SMTP auth extension implementation
 pub mod auth;
 pub use channel_message::ProcessMessage;
-pub use receiver::{handle_connection, AbstractIO, Connection, ConnectionKind, OnMail};
+pub use receiver::{handle_connection, AbstractIO, Connection, OnMail};
 pub use runtime::start_runtime;
 pub use server::{socket_bind_anyhow, Server};
 

--- a/src/vsmtp/vsmtp-server/src/lib.rs
+++ b/src/vsmtp/vsmtp-server/src/lib.rs
@@ -9,7 +9,6 @@
 #![warn(clippy::nursery)]
 #![warn(clippy::cargo)]
 //
-#![allow(clippy::doc_markdown)]
 #![allow(clippy::use_self)]
 
 #[cfg(test)]

--- a/src/vsmtp/vsmtp-server/src/receiver/connection.rs
+++ b/src/vsmtp/vsmtp-server/src/receiver/connection.rs
@@ -17,21 +17,9 @@
 use crate::{log_channels, AbstractIO};
 use vsmtp_common::{
     re::{anyhow, log, tokio},
-    CodeID, Reply, ReplyOrCodeID,
+    CodeID, ConnectionKind, Reply, ReplyOrCodeID,
 };
 use vsmtp_config::Config;
-
-/// how the server would react to tls interaction for this connection
-#[allow(clippy::module_name_repetitions)]
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, vsmtp_common::re::strum::Display)]
-pub enum ConnectionKind {
-    /// Connection coming for relay (MTA on port 25)
-    Relay,
-    /// Connection coming for submission (MSA on port 587)
-    Submission,
-    /// Connection coming for submissionS (MSA on port 465)
-    Tunneled,
-}
 
 // TODO:? merge with [`ConnectionContext`]
 /// Instance containing connection to the server's information

--- a/src/vsmtp/vsmtp-server/src/receiver/mod.rs
+++ b/src/vsmtp/vsmtp-server/src/receiver/mod.rs
@@ -26,7 +26,7 @@ use vsmtp_common::{
     re::{anyhow, log, tokio},
     state::StateSMTP,
     status::Status,
-    CodeID, MailParserOnFly,
+    CodeID, ConnectionKind, MailParserOnFly,
 };
 use vsmtp_config::{re::rustls, Resolvers};
 use vsmtp_rule_engine::rule_engine::RuleEngine;
@@ -37,7 +37,7 @@ mod io;
 mod on_mail;
 pub mod transaction;
 
-pub use connection::{Connection, ConnectionKind};
+pub use connection::Connection;
 pub use io::AbstractIO;
 pub use on_mail::{MailHandler, MailHandlerError, OnMail};
 

--- a/src/vsmtp/vsmtp-server/src/receiver/transaction.rs
+++ b/src/vsmtp/vsmtp-server/src/receiver/transaction.rs
@@ -28,7 +28,7 @@ use vsmtp_common::{
     status::Status,
     Address, CodeID, ReplyOrCodeID,
 };
-use vsmtp_config::{Config, Resolvers, TlsSecurityLevel};
+use vsmtp_config::{field::TlsSecurityLevel, Config, Resolvers};
 use vsmtp_rule_engine::{rule_engine::RuleEngine, rule_state::RuleState};
 
 enum ProcessedEvent {

--- a/src/vsmtp/vsmtp-server/src/runtime.rs
+++ b/src/vsmtp/vsmtp-server/src/runtime.rs
@@ -69,7 +69,7 @@ where
         .map_err(anyhow::Error::new)
 }
 
-/// Start the vSMTP server's runtime
+/// Start the `vSMTP` server's runtime
 ///
 /// # Errors
 ///

--- a/src/vsmtp/vsmtp-server/src/server.rs
+++ b/src/vsmtp/vsmtp-server/src/server.rs
@@ -43,7 +43,7 @@ pub struct Server {
     delivery_sender: tokio::sync::mpsc::Sender<ProcessMessage>,
 }
 
-/// Create a TCPListener ready to be listened to
+/// Create a `TCPListener` ready to be listened to
 ///
 /// # Errors
 ///
@@ -81,7 +81,7 @@ impl Server {
     /// # Errors
     ///
     /// * `spool_dir` does not exist and failed to be created
-    /// * cannot convert sockets to [tokio::net::TcpListener]
+    /// * cannot convert sockets to `[tokio::net::TcpListener]`
     /// * cannot initialize [rustls] config
     pub fn new(
         config: std::sync::Arc<Config>,
@@ -125,11 +125,9 @@ impl Server {
     }
 
     #[allow(clippy::too_many_lines)]
-    /// Main loop of vSMTP's server
+    /// Main loop of `vSMTP`'s server
     ///
     /// # Errors
-    ///
-    /// * failed to initialize the [RuleEngine]
     pub async fn listen_and_serve(
         self,
         sockets: (

--- a/src/vsmtp/vsmtp-server/src/server.rs
+++ b/src/vsmtp/vsmtp-server/src/server.rs
@@ -18,16 +18,14 @@ use crate::{
     auth,
     channel_message::ProcessMessage,
     log_channels,
-    receiver::{
-        handle_connection, MailHandler, {Connection, ConnectionKind},
-    },
+    receiver::{handle_connection, Connection, MailHandler},
 };
 use vsmtp_common::{
     re::{
         anyhow::{self, Context},
         log, tokio, vsmtp_rsasl,
     },
-    CodeID,
+    CodeID, ConnectionKind,
 };
 use vsmtp_config::{get_rustls_config, re::rustls, Config, Resolvers};
 use vsmtp_rule_engine::rule_engine::RuleEngine;

--- a/src/vsmtp/vsmtp-test/src/lib.rs
+++ b/src/vsmtp/vsmtp-test/src/lib.rs
@@ -7,8 +7,6 @@
 #![warn(clippy::pedantic)]
 #![warn(clippy::nursery)]
 #![warn(clippy::cargo)]
-//
-#![allow(clippy::doc_markdown)]
 
 /// Config shortcut
 pub mod config;

--- a/src/vsmtp/vsmtp-test/src/receiver.rs
+++ b/src/vsmtp/vsmtp-test/src/receiver.rs
@@ -18,11 +18,11 @@
 use vsmtp_common::{
     mail_context::MessageBody,
     re::{anyhow, tokio},
-    CodeID,
+    CodeID, ConnectionKind,
 };
 use vsmtp_config::Config;
 use vsmtp_rule_engine::rule_engine::RuleEngine;
-use vsmtp_server::{auth, handle_connection, Connection, ConnectionKind, OnMail};
+use vsmtp_server::{auth, handle_connection, Connection, OnMail};
 
 /// A type implementing Write+Read to emulate sockets
 pub struct Mock<'a, T: AsRef<[u8]> + Unpin> {

--- a/src/vsmtp/vsmtp-test/src/receiver.rs
+++ b/src/vsmtp/vsmtp-test/src/receiver.rs
@@ -89,7 +89,7 @@ impl OnMail for DefaultMailHandler {
     }
 }
 
-/// run a connection and assert output produced by vSMTP and @expected_output
+/// run a connection and assert output produced by `vSMTP` and `expected_output`
 ///
 /// # Errors
 ///
@@ -138,7 +138,7 @@ where
     result
 }
 
-/// Call test_receiver_inner
+/// Call `test_receiver_inner`
 #[macro_export]
 macro_rules! test_receiver {
     ($input:expr, $output:expr) => {

--- a/src/vsmtp/vsmtp-test/src/tests/tls/mod.rs
+++ b/src/vsmtp/vsmtp-test/src/tests/tls/mod.rs
@@ -22,7 +22,10 @@ mod tunneled_with_auth;
 const TEST_SERVER_CERT: &str = "src/template/certs/certificate.crt";
 const TEST_SERVER_KEY: &str = "src/template/certs/private_key.rsa.key";
 
-use vsmtp_common::re::{anyhow, tokio};
+use vsmtp_common::{
+    re::{anyhow, tokio},
+    ConnectionKind,
+};
 use vsmtp_config::{
     get_rustls_config,
     re::{rustls, rustls_pemfile},
@@ -30,7 +33,7 @@ use vsmtp_config::{
 };
 use vsmtp_rule_engine::rule_engine::RuleEngine;
 use vsmtp_server::auth;
-use vsmtp_server::{ConnectionKind, ProcessMessage, Server};
+use vsmtp_server::{ProcessMessage, Server};
 
 pub fn get_tls_config() -> Config {
     Config::builder()

--- a/src/vsmtp/vsmtp-test/src/tests/tls/starttls.rs
+++ b/src/vsmtp/vsmtp-test/src/tests/tls/starttls.rs
@@ -17,7 +17,7 @@
 use super::get_tls_config;
 use crate::{test_receiver, tests::tls::test_starttls};
 use vsmtp_common::re::{anyhow, tokio};
-use vsmtp_config::TlsSecurityLevel;
+use vsmtp_config::field::TlsSecurityLevel;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 3)]
 async fn simple() {

--- a/src/vsmtp/vsmtp-test/src/tests/tls/tunneled.rs
+++ b/src/vsmtp/vsmtp-test/src/tests/tls/tunneled.rs
@@ -17,7 +17,7 @@
 use super::get_tls_config;
 use crate::tests::tls::test_tls_tunneled;
 use vsmtp_common::re::tokio;
-use vsmtp_config::{get_rustls_config, ConfigServerVirtual, TlsSecurityLevel};
+use vsmtp_config::{get_rustls_config, FieldServerVirtual, TlsSecurityLevel};
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 3)]
 async fn simple() {
@@ -143,7 +143,7 @@ async fn sni() {
     config.server.tls.as_mut().unwrap().security_level = TlsSecurityLevel::Encrypt;
     config.server.r#virtual.insert(
         "second.testserver.com".to_string(),
-        ConfigServerVirtual::with_tls(
+        FieldServerVirtual::with_tls(
             "src/template/certs/sni/second.certificate.crt",
             "src/template/certs/sni/second.private_key.rsa.key",
         )

--- a/src/vsmtp/vsmtp-test/src/tests/tls/tunneled.rs
+++ b/src/vsmtp/vsmtp-test/src/tests/tls/tunneled.rs
@@ -17,7 +17,10 @@
 use super::get_tls_config;
 use crate::tests::tls::test_tls_tunneled;
 use vsmtp_common::re::tokio;
-use vsmtp_config::{get_rustls_config, FieldServerVirtual, TlsSecurityLevel};
+use vsmtp_config::{
+    field::{FieldServerVirtual, TlsSecurityLevel},
+    get_rustls_config,
+};
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 3)]
 async fn simple() {


### PR DESCRIPTION
# Summary of changes

## Removed

* `#![allow(clippy::doc_markdown)]` and fix the warning

## Changed

* move `ConnectionKind` in `vsmtp_common`
* serialize the `Reply` as the folding string generated
* update the module path in `vsmtp_config` and move field of the config in `field`
* move `vsmtp_config`'s helper under `#[doc(hidden)]`

## Added

* document the field in the config