### PR TITLE
Quarantine path restriction

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,6 +6,7 @@
         "authid",
         "authpass",
         "BITMIME",
+        "canonicalize",
         "capath",
         "CHACHA",
         "chrono",

--- a/examples/vsl/actions/dump.vsl
+++ b/examples/vsl/actions/dump.vsl
@@ -2,11 +2,11 @@
     preq: [
         action "dump raw email to disk" || {
             try {
-		dump("tests/generated");
-		next();
+                dump("tests/generated");
+                next();
             } catch (e) {
-		print(e);
-		deny();
+                print(e);
+                deny();
             }
         },
 
@@ -17,10 +17,10 @@
         action "dump parsed email to disk" || {
             try {
                 dump("tests/generated");
-		next();
+        		next();
             } catch (e) {
-		print(e);
-		deny();
+                print(e);
+                deny();
             }
         },
 

--- a/src/vsmtp/vsmtp-config/src/lib.rs
+++ b/src/vsmtp/vsmtp-config/src/lib.rs
@@ -161,29 +161,29 @@ pub fn create_app_folder(
         std::fs::create_dir_all(&config.app.dirpath)?;
     }
 
-    let app_dirpath = config.app.dirpath.canonicalize()?;
-    let full_path = path.map_or_else(|| app_dirpath.clone(), |path| app_dirpath.join(path));
+    let absolute_app_dirpath = config.app.dirpath.canonicalize()?;
+    let full_path = path.map_or_else(
+        || config.app.dirpath.clone(),
+        |path| config.app.dirpath.join(path),
+    );
 
-    // NOTE: `canonicalize` cannot be used before creating folders
-    //        because it checks if the result path exists or not.
-    // FIXME: Even if the path is invalid (`path` parameter uses
-    //        `..` or `/` to go out of the app dirpath) the folder
-    //        is created anyway.
     if !full_path.exists() {
         std::fs::create_dir_all(&full_path)?;
-    }
-
-    let full_path = full_path.canonicalize()?;
-
-    if full_path.starts_with(&app_dirpath) {
         chown(
             &full_path,
             Some(config.server.system.user.uid()),
             Some(config.server.system.group.gid()),
         )?;
 
-        Ok(full_path)
-    } else {
-        anyhow::bail!("Tried to create the app folder at {:?} but the root app directory {:?} is no longer the parent. All application output must be within the app directory path specified in the toml configuration.", full_path, config.app.dirpath)
+        // NOTE: `canonicalize` cannot be used before creating folders
+        //        because it checks if the result path exists or not.
+        // FIXME: Even if the path is invalid (`path` parameter uses
+        //        `..` or `/` to go out of the app dirpath) the folder
+        //        is created anyway.
+        if !full_path.canonicalize()?.starts_with(&absolute_app_dirpath) {
+            anyhow::bail!("Tried to create the app folder at {:?} but the root app directory {:?} is no longer the parent. All application output must be within the app directory path specified in the toml configuration.", full_path, config.app.dirpath)
+        }
     }
+
+    Ok(full_path)
 }

--- a/src/vsmtp/vsmtp-config/src/lib.rs
+++ b/src/vsmtp/vsmtp-config/src/lib.rs
@@ -157,14 +157,22 @@ pub fn create_app_folder(
     config: &Config,
     path: Option<&str>,
 ) -> anyhow::Result<std::path::PathBuf> {
-    let app_dirpath = config.app.dirpath.canonicalize()?;
+    if !config.app.dirpath.exists() {
+        std::fs::create_dir_all(&config.app.dirpath)?;
+    }
 
+    let app_dirpath = config.app.dirpath.canonicalize()?;
     let full_path = path.map_or_else(|| app_dirpath.clone(), |path| app_dirpath.join(path));
 
     // NOTE: `canonicalize` cannot be used before creating folders
     //        because it checks if the result path exists or not.
-    // FIXME: Even if the path is invalid, the folder is created anyway.
-    std::fs::create_dir_all(&full_path)?;
+    // FIXME: Even if the path is invalid (`path` parameter uses
+    //        `..` or `/` to go out of the app dirpath) the folder
+    //        is created anyway.
+    if !full_path.exists() {
+        std::fs::create_dir_all(&full_path)?;
+    }
+
     let full_path = full_path.canonicalize()?;
 
     if full_path.starts_with(&app_dirpath) {
@@ -173,6 +181,7 @@ pub fn create_app_folder(
             Some(config.server.system.user.uid()),
             Some(config.server.system.group.gid()),
         )?;
+
         Ok(full_path)
     } else {
         anyhow::bail!("Tried to create the app folder at {:?} but the root app directory {:?} is no longer the parent. All application output must be within the app directory path specified in the toml configuration.", full_path, config.app.dirpath)


### PR DESCRIPTION
## Changed

- the `quarantine(quarantine_path)` function can no longer get out of the application path specified in toml by the `[app.dirpath]` field.

```toml
[app]
dirpath = "/var/spool/vsmtp/my_queues"
```

```rust
#{
    preq: [
        // allowed, will be created at `/var/spool/vsmtp/my_queues/virus_q`.
        rule "quarantine 1" || quarantine("virus_q"),
        // invalid, would override app.dirpath by `/virus_q`, will emit an error.
        rule "quarantine 2" || quarantine("/virus_q"),
        // invalid, would override app.dirpath by `/var/spool/vsmtp/virus_q`, will emit an error.
        rule "quarantine 3" || quarantine("../virus_q"),
    ],
}
```