### PR TITLE
Add `documentation` & `keywords` in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,10 +7,13 @@ license = "GPL-3.0-only"
 
 authors = ["Team viridIT <https://viridit.com/>"]
 description = "Next-gen MTA. Secured, Faster and Greener"
+
 homepage = "https://github.com/viridIT/vSMTP"
 repository = "https://github.com/viridIT/vSMTP"
+documentation = "https://docs.rs/crate/vsmtp/"
+
 readme = "README.md"
-keywords = ["vsmtp"]
+keywords = ["vsmtp", "mta", "smtp"]
 categories = ["email"]
 
 rust-version = "1.58"

--- a/src/vqueue/Cargo.toml
+++ b/src/vqueue/Cargo.toml
@@ -9,8 +9,11 @@ rust-version = "1.58"
 
 authors = ["Team viridIT <https://viridit.com/>"]
 description = "vSMTP's queues mananger. Secured, Faster and Greener"
+
 homepage = "https://github.com/viridIT/vSMTP"
 repository = "https://github.com/viridIT/vSMTP"
+documentation = "https://docs.rs/crate/vqueue/"
+
 readme = "../../README.md"
 keywords = ["vsmtp"]
 categories = ["command-line-utilities"]

--- a/src/vsmtp/vsmtp-common/Cargo.toml
+++ b/src/vsmtp/vsmtp-common/Cargo.toml
@@ -9,8 +9,11 @@ rust-version = "1.58"
 
 authors = ["Team viridIT <https://viridit.com/>"]
 description = "Next-gen MTA. Secured, Faster and Greener"
+
 homepage = "https://github.com/viridIT/vSMTP"
 repository = "https://github.com/viridIT/vSMTP"
+documentation = "https://docs.rs/crate/vsmtp-common/"
+
 readme = "../../../README.md"
 keywords = ["vsmtp"]
 categories = ["data-structures"]

--- a/src/vsmtp/vsmtp-config/Cargo.toml
+++ b/src/vsmtp/vsmtp-config/Cargo.toml
@@ -9,8 +9,11 @@ rust-version = "1.58"
 
 authors = ["Team viridIT <https://viridit.com/>"]
 description = "Next-gen MTA. Secured, Faster and Greener"
+
 homepage = "https://github.com/viridIT/vSMTP"
 repository = "https://github.com/viridIT/vSMTP"
+documentation = "https://docs.rs/crate/vsmtp-config/"
+
 readme = "../../../README.md"
 keywords = ["vsmtp"]
 categories = ["data-structures"]

--- a/src/vsmtp/vsmtp-delivery/Cargo.toml
+++ b/src/vsmtp/vsmtp-delivery/Cargo.toml
@@ -9,8 +9,11 @@ rust-version = "1.58"
 
 authors = ["Team viridIT <https://viridit.com/>"]
 description = "Next-gen MTA. Secured, Faster and Greener"
+
 homepage = "https://github.com/viridIT/vSMTP"
 repository = "https://github.com/viridIT/vSMTP"
+documentation = "https://docs.rs/crate/vsmtp-delivery/"
+
 readme = "../../../README.md"
 keywords = ["vsmtp"]
 categories = ["network-programming"]

--- a/src/vsmtp/vsmtp-mail-parser/Cargo.toml
+++ b/src/vsmtp/vsmtp-mail-parser/Cargo.toml
@@ -9,8 +9,11 @@ rust-version = "1.58"
 
 authors = ["Team viridIT <https://viridit.com/>"]
 description = "Next-gen MTA. Secured, Faster and Greener"
+
 homepage = "https://github.com/viridIT/vSMTP"
 repository = "https://github.com/viridIT/vSMTP"
+documentation = "https://docs.rs/crate/vsmtp-mail-parser/"
+
 readme = "../../../README.md"
 keywords = ["vsmtp"]
 categories = ["email"]

--- a/src/vsmtp/vsmtp-rule-engine/Cargo.toml
+++ b/src/vsmtp/vsmtp-rule-engine/Cargo.toml
@@ -9,10 +9,19 @@ rust-version = "1.58"
 
 authors = ["Team viridIT <https://viridit.com/>"]
 description = "Next-gen MTA. Secured, Faster and Greener"
+
 homepage = "https://github.com/viridIT/vSMTP"
 repository = "https://github.com/viridIT/vSMTP"
+documentation = "https://docs.rs/crate/vsmtp-rule-engine/"
+
 readme = "../../../README.md"
-keywords = ["vsmtp"]
+keywords = [
+  "vsmtp",
+  "scripting-engine",
+  "scripting-language",
+  "scripting",
+  "rhai",
+]
 categories = ["config"]
 
 [dependencies]

--- a/src/vsmtp/vsmtp-server/Cargo.toml
+++ b/src/vsmtp/vsmtp-server/Cargo.toml
@@ -9,10 +9,13 @@ rust-version = "1.58"
 
 authors = ["Team viridIT <https://viridit.com/>"]
 description = "Next-gen MTA. Secured, Faster and Greener"
+
 homepage = "https://github.com/viridIT/vSMTP"
 repository = "https://github.com/viridIT/vSMTP"
+documentation = "https://docs.rs/crate/vsmtp-server/"
+
 readme = "../../../README.md"
-keywords = ["vsmtp"]
+keywords = ["vsmtp", "email", "server", "mail-server"]
 categories = ["network-programming"]
 
 [dependencies]


### PR DESCRIPTION
# Summary of changes

## Added

* add the `documentation` field of the Cargo.toml for each crate with the links to the `docs.rs` site
* add a function `RuleState::just_run_when` to abstract the logics when used to run on one `StateSMTP`
