### PR TITLE
SPF fix

### DIFF
--- a/src/vsmtp/vsmtp-rule-engine/src/modules/actions/security.rs
+++ b/src/vsmtp/vsmtp-rule-engine/src/modules/actions/security.rs
@@ -73,16 +73,7 @@ pub mod security {
             )
         };
 
-        let resolver = srv
-            .resolvers
-            .get(mail_from.domain())
-            .ok_or_else::<Box<EvalAltResult>, _>(|| {
-                format!(
-                    "no dns configuration found for {} while checking spf.",
-                    mail_from.domain()
-                )
-                .into()
-            })?;
+        let resolver = srv.resolvers.get(&srv.config.server.domain).unwrap();
 
         match identity {
             "mail_from" => {


### PR DESCRIPTION
## Changed
- root dns is used when using the `spf_check` function, allowing any domain to be checked.

closes #398