### PR TITLE
Prepend headers

### DIFF
--- a/src/vsmtp/vsmtp-common/src/mail_context.rs
+++ b/src/vsmtp/vsmtp-common/src/mail_context.rs
@@ -128,12 +128,25 @@ impl MessageBody {
         }
     }
 
-    /// prepend a header to the header section.
+    /// push a header to the header section.
     pub fn add_header(&mut self, name: &str, value: &str) {
         match self {
             Self::Raw { headers, .. } => {
                 // TODO: handle folding ?
                 headers.push(format!("{name}: {value}"));
+            }
+            Self::Parsed(parsed) => {
+                parsed.push_headers([(name.to_string(), value.to_string())]);
+            }
+        }
+    }
+
+    /// prepend a header to the header section.
+    pub fn prepend_header(&mut self, name: &str, value: &str) {
+        match self {
+            Self::Raw { headers, .. } => {
+                // TODO: handle folding ?
+                headers.splice(..0, [format!("{name}: {value}")]);
             }
             Self::Parsed(parsed) => {
                 parsed.prepend_headers([(name.to_string(), value.to_string())]);

--- a/src/vsmtp/vsmtp-common/src/mail_context.rs
+++ b/src/vsmtp/vsmtp-common/src/mail_context.rs
@@ -122,14 +122,14 @@ impl MessageBody {
                         _ => {}
                     }
                 }
-                self.add_header(name, value);
+                self.append_header(name, value);
             }
             Self::Parsed(parsed) => parsed.set_header(name, value),
         }
     }
 
     /// push a header to the header section.
-    pub fn add_header(&mut self, name: &str, value: &str) {
+    pub fn append_header(&mut self, name: &str, value: &str) {
         match self {
             Self::Raw { headers, .. } => {
                 // TODO: handle folding ?

--- a/src/vsmtp/vsmtp-common/src/message/mail.rs
+++ b/src/vsmtp/vsmtp-common/src/message/mail.rs
@@ -186,12 +186,13 @@ impl Mail {
             .map(|(_, value)| value.as_str())
     }
 
-    /// prepend new headers to the email, folding if necessary.
+    // NOTE: would a double ended queue / linked list interesting in this case ?
+    /// prepend new headers to the email.
     pub fn prepend_headers(&mut self, headers: impl IntoIterator<Item = (String, String)>) {
         self.headers.splice(..0, headers);
     }
 
-    /// push new headers to the email, folding if necessary.
+    /// push new headers to the email.
     pub fn push_headers(&mut self, headers: impl IntoIterator<Item = (String, String)>) {
         self.headers.extend(headers);
     }

--- a/src/vsmtp/vsmtp-common/src/message/mail.rs
+++ b/src/vsmtp/vsmtp-common/src/message/mail.rs
@@ -256,7 +256,7 @@ mod test {
     }
 
     #[test]
-    fn test_add_headers() {
+    fn test_append_headers() {
         let mut mail = Mail {
             body: BodyType::Regular(vec!["email content".to_string()]),
             ..Mail::default()

--- a/src/vsmtp/vsmtp-mail-parser/src/tests/mime_parser/methods.rs
+++ b/src/vsmtp/vsmtp-mail-parser/src/tests/mime_parser/methods.rs
@@ -61,7 +61,7 @@ fn test_get_header() {
 }
 
 #[test]
-fn test_set_and_add_header() {
+fn test_set_and_append_header() {
     use crate::tests::mime_parser::methods::generate_test_bodies;
 
     let (mut raw, mut parsed) = generate_test_bodies();

--- a/src/vsmtp/vsmtp-rule-engine/src/api/auth.rhai
+++ b/src/vsmtp/vsmtp-rule-engine/src/api/auth.rhai
@@ -114,11 +114,11 @@ fn check_spf(identity, header, policy) {
     switch header {
         // It is RECOMMENDED that SMTP receivers record the result"
         "none" => {},
-        "spf" => add_header("Received-SPF", spf_header),
-        "auth" => add_header("Authentication-Results", auth_header),
+        "spf" => prepend_header("Received-SPF", spf_header),
+        "auth" => prepend_header("Authentication-Results", auth_header),
         _ => {
-            add_header("Authentication-Results", auth_header);
-            add_header("Received-SPF", spf_header);
+            prepend_header("Authentication-Results", auth_header);
+            prepend_header("Received-SPF", spf_header);
         },
     }
 
@@ -166,7 +166,7 @@ fn check_null_mx_sender() {
     // There's no standard header for null MX
     if srv_domain.auth.null_mx.header == "X-nullMX" {
         let header = `${hostname()}; null MX sender detected for ${ctx().mail_from.domain}`;
-        sys::add_header(ctx(), "X-NullMX", header);
+        sys::prepend_header(ctx(), "X-NullMX", header);
     }
 
     // Modify the subject

--- a/src/vsmtp/vsmtp-rule-engine/src/api/sys-api.rhai
+++ b/src/vsmtp/vsmtp-rule-engine/src/api/sys-api.rhai
@@ -15,6 +15,7 @@ fn quarantine(queue) { sys::quarantine(ctx(), queue) }
 fn has_header(header) { sys::has_header(msg(), header) }
 fn get_header(header) { sys::get_header(msg(), header) }
 fn add_header(header, value) { sys::add_header(msg(), header, value) }
+fn prepend_header(header, value) { sys::prepend_header(msg(), header, value) }
 fn set_header(header, value) { sys::set_header(msg(), header, value) }
 fn add_to(addr) { sys::add_to(msg(), addr) }
 fn remove_to(addr) { sys::remove_to(msg(), addr) }

--- a/src/vsmtp/vsmtp-rule-engine/src/api/sys-api.rhai
+++ b/src/vsmtp/vsmtp-rule-engine/src/api/sys-api.rhai
@@ -14,7 +14,7 @@ fn quarantine(queue) { sys::quarantine(ctx(), queue) }
 /// Header handling (headers.rs)
 fn has_header(header) { sys::has_header(msg(), header) }
 fn get_header(header) { sys::get_header(msg(), header) }
-fn add_header(header, value) { sys::add_header(msg(), header, value) }
+fn append_header(header, value) { sys::append_header(msg(), header, value) }
 fn prepend_header(header, value) { sys::prepend_header(msg(), header, value) }
 fn set_header(header, value) { sys::set_header(msg(), header, value) }
 fn add_to(addr) { sys::add_to(msg(), addr) }

--- a/src/vsmtp/vsmtp-rule-engine/src/modules/message.rs
+++ b/src/vsmtp/vsmtp-rule-engine/src/modules/message.rs
@@ -47,9 +47,9 @@ pub mod message {
 
     /// add a header to the end of the raw or parsed email contained in ctx.
     #[rhai_fn(global, return_raw, pure)]
-    pub fn add_header(this: &mut Message, header: &str, value: &str) -> EngineResult<()> {
+    pub fn append_header(this: &mut Message, header: &str, value: &str) -> EngineResult<()> {
         vsl_missing_ok!(mut vsl_guard_ok!(this.write()), "message", StateSMTP::PreQ)
-            .add_header(header, value);
+            .append_header(header, value);
         Ok(())
     }
 

--- a/src/vsmtp/vsmtp-rule-engine/src/modules/message.rs
+++ b/src/vsmtp/vsmtp-rule-engine/src/modules/message.rs
@@ -45,11 +45,19 @@ pub mod message {
         )
     }
 
-    /// add a header to the raw or parsed email contained in ctx.
+    /// add a header to the end of the raw or parsed email contained in ctx.
     #[rhai_fn(global, return_raw, pure)]
     pub fn add_header(this: &mut Message, header: &str, value: &str) -> EngineResult<()> {
         vsl_missing_ok!(mut vsl_guard_ok!(this.write()), "message", StateSMTP::PreQ)
             .add_header(header, value);
+        Ok(())
+    }
+
+    /// prepend a header to the raw or parsed email contained in ctx.
+    #[rhai_fn(global, return_raw, pure)]
+    pub fn prepend_header(this: &mut Message, header: &str, value: &str) -> EngineResult<()> {
+        vsl_missing_ok!(mut vsl_guard_ok!(this.write()), "message", StateSMTP::PreQ)
+            .prepend_header(header, value);
         Ok(())
     }
 

--- a/src/vsmtp/vsmtp-rule-engine/src/tests/email/mutate_header/main.vsl
+++ b/src/vsmtp/vsmtp-rule-engine/src/tests/email/mutate_header/main.vsl
@@ -21,10 +21,17 @@ fn mutate_headers() {
     add_header("From", "<john@doe.com>");
     add_header("To", "<green@foo.net>");
 
+    prepend_header("X-VSMTP-STATUS", "delivered");
+    prepend_header("X-VSMTP-TRACING", "empty");
+    prepend_header("X-VSMTP-SENDER", "example.com");
+
     if !has_header("X-New-Header")
     || !has_header("X-Another-Header")
     || !has_header("From")
     || !has_header("To")
+    || !has_header("X-VSMTP-STATUS")
+    || !has_header("X-VSMTP-TRACING")
+    || !has_header("X-VSMTP-SENDER")
     {
         return deny();
     }
@@ -33,6 +40,7 @@ fn mutate_headers() {
     set_header("X-Yet-Another-Header", "adding to header section when not found");
 
     print(get_header("X-New-Header"));
+    print(get_header("X-VSMTP-STATUS"));
 
     if !has_header("X-New-Header")
     || !has_header("X-Yet-Another-Header")
@@ -45,6 +53,9 @@ fn mutate_headers() {
     && get_header("From") == "<john@doe.com>"
     && get_header("To") == "<green@foo.net>"
     && get_header("X-Yet-Another-Header") == "adding to header section when not found"
+    && get_header("X-VSMTP-STATUS") == "delivered"
+    && get_header("X-VSMTP-TRACING") == "empty"
+    && get_header("X-VSMTP-SENDER") == "example.com"
     {
         next()
     } else {

--- a/src/vsmtp/vsmtp-rule-engine/src/tests/email/mutate_header/main.vsl
+++ b/src/vsmtp/vsmtp-rule-engine/src/tests/email/mutate_header/main.vsl
@@ -16,10 +16,10 @@
 */
 
 fn mutate_headers() {
-    add_header("X-New-Header", "value of header");
-    add_header("X-Another-Header", "value of another");
-    add_header("From", "<john@doe.com>");
-    add_header("To", "<green@foo.net>");
+    append_header("X-New-Header", "value of header");
+    append_header("X-Another-Header", "value of another");
+    append_header("From", "<john@doe.com>");
+    append_header("To", "<green@foo.net>");
 
     prepend_header("X-VSMTP-STATUS", "delivered");
     prepend_header("X-VSMTP-TRACING", "empty");

--- a/src/vsmtp/vsmtp-server/src/delivery/mod.rs
+++ b/src/vsmtp/vsmtp-server/src/delivery/mod.rs
@@ -240,7 +240,7 @@ fn add_trace_information(
         .as_ref()
         .ok_or_else(|| anyhow::anyhow!("missing email metadata"))?;
 
-    message.add_header(
+    message.append_header(
         "X-VSMTP",
         &create_vsmtp_status_stamp(
             &metadata.message_id,
@@ -248,7 +248,7 @@ fn add_trace_information(
             rule_engine_result,
         ),
     );
-    message.add_header(
+    message.append_header(
         "Received",
         &create_received_stamp(
             &ctx.envelop.helo,


### PR DESCRIPTION
## Added
- a `prepend_header` vsl function to ... prepend headers to the email.

## Changed
- rename `add_header` vsl function to `append_header` to be consistent with `prepend_header`.

```rust
#{
  preq: [
    action "add reception headers" || {
      prepend_header("X-VSMTP-STATUS", "received");
      prepend_header("X-VSMTP-SENDER", `${ctx().mail_from}`);
      append_header("X-JOHN", "received by john's smtp server");
    },
  ],
}
``` 
will output add those headers to the mail.

```eml
X-VSMTP-STATUS: received
X-VSMTP-SENDER: example.com
From: any@example.com
Date: ...
...
X-JOHN: received by john's smtp server

this is the body of the email
...
```

closes #402