### PR TITLE
Message body refactoring

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -49,6 +49,7 @@
         "pemfile",
         "PKCS8",
         "postq",
+        "prepending",
         "preq",
         "rcpts",
         "RDONLY",

--- a/examples/vsl/actions/write.vsl
+++ b/examples/vsl/actions/write.vsl
@@ -1,14 +1,9 @@
 #{
     mail: [
-        rule "fail write to disk: body not received" || {
-            try {
-                write("tests/generated");
-                return deny();
-            } catch (err) {
-                if "failed to write email: the body has not been received yet" in err { return next(); } else {
-                    return deny();
-                }
-            }
+        rule "partial write to disk, body not received" || {
+            prepend_header("X-VSMTP-INIT", "done.");
+            write("tests/generated");
+            next()
         },
 
         rule "trailing mail" || accept(),

--- a/src/vsmtp/vsmtp-common/src/mail_context.rs
+++ b/src/vsmtp/vsmtp-common/src/mail_context.rs
@@ -50,7 +50,7 @@ pub enum MessageBody {
         /// The headers of the top level message
         headers: Vec<String>,
         /// Complete body of the message
-        body: String,
+        body: Option<String>,
     },
     /// The message parsed using a [`MailParser`]
     Parsed(Box<Mail>),
@@ -65,7 +65,7 @@ impl std::fmt::Display for MessageBody {
                     f.write_str("\r\n")?;
                 }
                 f.write_str("\r\n")?;
-                f.write_str(body)
+                f.write_str(body.as_ref().map_or("", std::string::String::as_str))
             }
             Self::Parsed(mail) => f.write_fmt(format_args!("{mail}")),
         }
@@ -80,7 +80,8 @@ impl MessageBody {
     /// * Fail to parse using the provided [`MailParser`]
     pub fn to_parsed<P: MailParser>(&mut self) -> anyhow::Result<()> {
         if let Self::Raw { headers, body } = self {
-            *self = P::default().parse_raw(std::mem::take(headers), std::mem::take(body))?;
+            *self =
+                P::default().parse_raw(std::mem::take(headers), body.take().unwrap_or_default())?;
         }
         Ok(())
     }

--- a/src/vsmtp/vsmtp-common/src/mail_context.rs
+++ b/src/vsmtp/vsmtp-common/src/mail_context.rs
@@ -56,6 +56,15 @@ pub enum MessageBody {
     Parsed(Box<Mail>),
 }
 
+impl Default for MessageBody {
+    fn default() -> Self {
+        Self::Raw {
+            headers: vec![],
+            body: None,
+        }
+    }
+}
+
 impl std::fmt::Display for MessageBody {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -73,6 +82,21 @@ impl std::fmt::Display for MessageBody {
 }
 
 impl MessageBody {
+    /// add headers from another body to the current instance.
+    pub fn extend_raw_headers(&mut self, other: &Self) {
+        if let MessageBody::Raw { headers, .. } = self {
+            let to_extend = headers;
+            match other {
+                MessageBody::Raw { headers, .. } => to_extend.extend(headers.clone()),
+                MessageBody::Parsed(o) => to_extend.extend(
+                    o.headers
+                        .iter()
+                        .map(|(name, value)| format!("{name}: {value}")),
+                ),
+            }
+        };
+    }
+
     /// Create a new instance of [`MessageBody::Parsed`], cloning if already parsed
     ///
     /// # Errors

--- a/src/vsmtp/vsmtp-common/src/mail_context.rs
+++ b/src/vsmtp/vsmtp-common/src/mail_context.rs
@@ -82,19 +82,13 @@ impl std::fmt::Display for MessageBody {
 }
 
 impl MessageBody {
-    /// add headers from another body to the current instance.
-    pub fn extend_raw_headers(&mut self, other: &Self) {
+    ///
+    pub fn take_headers(&mut self) -> Vec<String> {
         if let MessageBody::Raw { headers, .. } = self {
-            let to_extend = headers;
-            match other {
-                MessageBody::Raw { headers, .. } => to_extend.extend(headers.clone()),
-                MessageBody::Parsed(o) => to_extend.extend(
-                    o.headers
-                        .iter()
-                        .map(|(name, value)| format!("{name}: {value}")),
-                ),
-            }
-        };
+            return std::mem::take(headers);
+        }
+
+        vec![]
     }
 
     /// Create a new instance of [`MessageBody::Parsed`], cloning if already parsed
@@ -176,6 +170,13 @@ impl MessageBody {
             Self::Parsed(parsed) => {
                 parsed.prepend_headers([(name.to_string(), value.to_string())]);
             }
+        }
+    }
+
+    /// prepend a set of headers to the header section.
+    pub fn prepend_raw_headers(&mut self, to_prepend: impl Iterator<Item = String>) {
+        if let MessageBody::Raw { headers, .. } = self {
+            headers.splice(..0, to_prepend);
         }
     }
 }

--- a/src/vsmtp/vsmtp-mail-parser/src/tests/mime_parser/methods.rs
+++ b/src/vsmtp/vsmtp-mail-parser/src/tests/mime_parser/methods.rs
@@ -43,7 +43,10 @@ fn generate_test_bodies() -> (MessageBody, MessageBody) {
 "#
     .to_string();
 
-    let raw = MessageBody::Raw { headers, body };
+    let raw = MessageBody::Raw {
+        headers,
+        body: Some(body),
+    };
     let mut parsed = raw.clone();
     parsed.to_parsed::<MailMimeParser>().unwrap();
 

--- a/src/vsmtp/vsmtp-rule-engine/src/dsl/directives.rs
+++ b/src/vsmtp/vsmtp-rule-engine/src/dsl/directives.rs
@@ -85,12 +85,7 @@ impl Directive {
                             .map_err::<Box<rhai::EvalAltResult>, _>(|_| {
                                 "context mutex poisoned".into()
                             })?
-                            .as_ref()
-                            .map(std::string::ToString::to_string)
-                            .ok_or_else::<Box<rhai::EvalAltResult>, _>(|| {
-                                "tried to delegate email security but the body was empty".into()
-                            })?;
-
+                            .to_string();
                         (
                             ctx.envelop.mail_from.clone(),
                             ctx.envelop.rcpt.clone(),

--- a/src/vsmtp/vsmtp-rule-engine/src/error.rs
+++ b/src/vsmtp/vsmtp-rule-engine/src/error.rs
@@ -150,14 +150,13 @@ macro_rules! vsl_missing_ok {
 }
 
 macro_rules! vsl_parse_ok {
-    ($writer:expr) => {{
-        let message = vsl_missing_ok!(mut $writer, "message", StateSMTP::PreQ);
-        if !matches!(&message, MessageBody::Parsed(..)) {
-            message
+    ($message:expr) => {{
+        if !matches!(&*$message, MessageBody::Parsed(..)) {
+            $message
                 .to_parsed::<vsmtp_mail_parser::MailMimeParser>()
                 .map_err(|source| $crate::error::RuntimeError::ParseMessageBody { source })?;
         }
-        vsl_missing_ok!(mut $writer, "message", StateSMTP::PreQ)
+        $message
     }};
 }
 

--- a/src/vsmtp/vsmtp-rule-engine/src/modules/actions/write.rs
+++ b/src/vsmtp/vsmtp-rule-engine/src/modules/actions/write.rs
@@ -59,18 +59,8 @@ pub mod write {
             .read()
             .map_err::<Box<EvalAltResult>, _>(|e| e.to_string().into())?;
 
-        std::io::Write::write_all(
-            &mut writer,
-            body.as_ref()
-                .ok_or_else::<Box<EvalAltResult>, _>(|| {
-                    "failed to write email: the body has not been received yet."
-                        .to_string()
-                        .into()
-                })?
-                .to_string()
-                .as_bytes(),
-        )
-        .map_err(|err| format!("failed to write email at {dir:?}: {err}").into())
+        std::io::Write::write_all(&mut writer, body.to_string().as_bytes())
+            .map_err(|err| format!("failed to write email at {dir:?}: {err}").into())
     }
 
     /// write the content of the current email with it's metadata in a json file.

--- a/src/vsmtp/vsmtp-rule-engine/src/modules/message.rs
+++ b/src/vsmtp/vsmtp-rule-engine/src/modules/message.rs
@@ -20,59 +20,50 @@ use rhai::plugin::{
     mem, Dynamic, EvalAltResult, FnAccess, FnNamespace, ImmutableString, Module, NativeCallContext,
     PluginFunction, RhaiResult, TypeId,
 };
-use vsmtp_common::{rcpt::Rcpt, state::StateSMTP, Address};
+use vsmtp_common::{rcpt::Rcpt, Address};
 
 #[rhai::plugin::export_module]
 pub mod message {
     /// check if a given header exists in the top level headers.
     #[rhai_fn(global, return_raw, pure)]
     pub fn has_header(this: &mut Message, header: &str) -> EngineResult<bool> {
-        Ok(
-            vsl_missing_ok!(vsl_guard_ok!(this.read()), "message", StateSMTP::PreQ)
-                .get_header(header)
-                .is_some(),
-        )
+        Ok(vsl_guard_ok!(this.read()).get_header(header).is_some())
     }
 
     /// return the value of a header if it exists. Otherwise, returns an empty string.
     #[rhai_fn(global, return_raw, pure)]
     pub fn get_header(this: &mut Message, header: &str) -> EngineResult<String> {
-        Ok(
-            vsl_missing_ok!(vsl_guard_ok!(this.read()), "message", StateSMTP::PreQ)
-                .get_header(header)
-                .map(ToString::to_string)
-                .unwrap_or_default(),
-        )
+        Ok(vsl_guard_ok!(this.read())
+            .get_header(header)
+            .map(ToString::to_string)
+            .unwrap_or_default())
     }
 
     /// add a header to the end of the raw or parsed email contained in ctx.
     #[rhai_fn(global, return_raw, pure)]
     pub fn append_header(this: &mut Message, header: &str, value: &str) -> EngineResult<()> {
-        vsl_missing_ok!(mut vsl_guard_ok!(this.write()), "message", StateSMTP::PreQ)
-            .append_header(header, value);
+        vsl_guard_ok!(this.write()).append_header(header, value);
         Ok(())
     }
 
     /// prepend a header to the raw or parsed email contained in ctx.
     #[rhai_fn(global, return_raw, pure)]
     pub fn prepend_header(this: &mut Message, header: &str, value: &str) -> EngineResult<()> {
-        vsl_missing_ok!(mut vsl_guard_ok!(this.write()), "message", StateSMTP::PreQ)
-            .prepend_header(header, value);
+        vsl_guard_ok!(this.write()).prepend_header(header, value);
         Ok(())
     }
 
     /// set a header to the raw or parsed email contained in ctx.
     #[rhai_fn(global, return_raw, pure)]
     pub fn set_header(this: &mut Message, header: &str, value: &str) -> EngineResult<()> {
-        vsl_missing_ok!(mut vsl_guard_ok!(this.write()), "message", StateSMTP::PreQ)
-            .set_header(header, value);
+        vsl_guard_ok!(this.write()).set_header(header, value);
         Ok(())
     }
 
     /// Get the message body as a string
     #[rhai_fn(global, get = "mail", return_raw, pure)]
     pub fn mail(this: &mut Message) -> EngineResult<String> {
-        Ok(vsl_missing_ok!(vsl_guard_ok!(this.read()), "mail", StateSMTP::PreQ).to_string())
+        Ok(vsl_guard_ok!(this.read()).to_string())
     }
 
     /// Change the sender of the envelop
@@ -155,7 +146,7 @@ pub mod message_calling_parse {
         let new_addr = vsl_conversion_ok!("address", Address::try_from(new_addr.to_string()));
 
         let mut writer = vsl_guard_ok!(this.write());
-        match vsl_parse_ok!(writer) {
+        match &mut *vsl_parse_ok!(writer) {
             MessageBody::Parsed(body) => body.rewrite_mail_from(new_addr.full()),
             MessageBody::Raw { .. } => unreachable!("the message has been parsed just above"),
         }
@@ -172,7 +163,7 @@ pub mod message_calling_parse {
         let old_addr = vsl_conversion_ok!("address", Address::try_from(old_addr.to_string()));
 
         let mut writer = vsl_guard_ok!(this.write());
-        match vsl_parse_ok!(writer) {
+        match &mut *vsl_parse_ok!(writer) {
             MessageBody::Parsed(body) => body.rewrite_rcpt(old_addr.full(), new_addr.full()),
             MessageBody::Raw { .. } => unreachable!("the message has been parsed just above"),
         }
@@ -185,7 +176,7 @@ pub mod message_calling_parse {
         let new_addr = vsl_conversion_ok!("address", Address::try_from(new_addr.to_string()));
 
         let mut writer = vsl_guard_ok!(this.write());
-        match vsl_parse_ok!(writer) {
+        match &mut *vsl_parse_ok!(writer) {
             MessageBody::Parsed(body) => body.add_rcpt(new_addr.full()),
             MessageBody::Raw { .. } => unreachable!("the message has been parsed just above"),
         }
@@ -198,7 +189,7 @@ pub mod message_calling_parse {
         let addr = vsl_conversion_ok!("address", Address::try_from(addr.to_string()));
 
         let mut writer = vsl_guard_ok!(this.write());
-        match vsl_parse_ok!(writer) {
+        match &mut *vsl_parse_ok!(writer) {
             MessageBody::Parsed(body) => body.remove_rcpt(addr.full()),
             MessageBody::Raw { .. } => unreachable!("the message has been parsed just above"),
         }

--- a/src/vsmtp/vsmtp-rule-engine/src/modules/types.rs
+++ b/src/vsmtp/vsmtp-rule-engine/src/modules/types.rs
@@ -35,7 +35,7 @@ pub mod types {
 
     // type aliases for complex struct names
     pub type Context = std::sync::Arc<std::sync::RwLock<MailContext>>;
-    pub type Message = std::sync::Arc<std::sync::RwLock<Option<MessageBody>>>;
+    pub type Message = std::sync::Arc<std::sync::RwLock<MessageBody>>;
     pub type Server = std::sync::Arc<ServerAPI>;
 
     // Status

--- a/src/vsmtp/vsmtp-rule-engine/src/tests/actions.rs
+++ b/src/vsmtp/vsmtp-rule-engine/src/tests/actions.rs
@@ -96,7 +96,7 @@ fn test_context_write() {
             "To: green@foo.net".to_string(),
             "Subject: test email".to_string(),
         ],
-        body: "This is a raw email.".to_string(),
+        body: Some("This is a raw email.".to_string()),
     });
     assert_eq!(
         re.run_when(&mut state, &StateSMTP::PreQ),
@@ -141,7 +141,7 @@ fn test_context_dump() {
     });
     *state.message().write().unwrap() = Some(MessageBody::Raw {
         headers: vec![],
-        body: "".to_string(),
+        body: Some("".to_string()),
     });
     assert_eq!(
         re.run_when(&mut state, &StateSMTP::PreQ),
@@ -187,7 +187,7 @@ fn test_quarantine() {
     });
     *state.message().write().unwrap() = Some(MessageBody::Raw {
         headers: vec![],
-        body: "".to_string(),
+        body: Some("".to_string()),
     });
     assert_eq!(
         re.run_when(&mut state, &StateSMTP::PreQ),

--- a/src/vsmtp/vsmtp-rule-engine/src/tests/actions.rs
+++ b/src/vsmtp/vsmtp-rule-engine/src/tests/actions.rs
@@ -90,14 +90,14 @@ fn test_context_write() {
         re.run_when(&mut state, &StateSMTP::MailFrom),
         Status::Accept(ReplyOrCodeID::CodeID(CodeID::Ok)),
     );
-    *state.message().write().unwrap() = Some(MessageBody::Raw {
+    *state.message().write().unwrap() = MessageBody::Raw {
         headers: vec![
             "From: john doe <john@doe.com>".to_string(),
             "To: green@foo.net".to_string(),
             "Subject: test email".to_string(),
         ],
         body: Some("This is a raw email.".to_string()),
-    });
+    };
     assert_eq!(
         re.run_when(&mut state, &StateSMTP::PreQ),
         Status::Accept(ReplyOrCodeID::CodeID(CodeID::Ok)),
@@ -139,22 +139,22 @@ fn test_context_dump() {
         timestamp: std::time::SystemTime::now(),
         skipped: None,
     });
-    *state.message().write().unwrap() = Some(MessageBody::Raw {
+    *state.message().write().unwrap() = MessageBody::Raw {
         headers: vec![],
         body: Some("".to_string()),
-    });
+    };
     assert_eq!(
         re.run_when(&mut state, &StateSMTP::PreQ),
         Status::Accept(ReplyOrCodeID::CodeID(CodeID::Ok)),
     );
-    *state.message().write().unwrap() = Some(MessageBody::Parsed(Box::new(Mail {
+    *state.message().write().unwrap() = MessageBody::Parsed(Box::new(Mail {
         headers: vec![
             ("From".to_string(), "john@doe.com".to_string()),
             ("To".to_string(), "green@bar.net".to_string()),
             ("X-Custom-Header".to_string(), "my header".to_string()),
         ],
         body: BodyType::Regular(vec!["this is an empty body".to_string()]),
-    })));
+    }));
     assert_eq!(
         re.run_when(&mut state, &StateSMTP::PostQ),
         Status::Accept(ReplyOrCodeID::CodeID(CodeID::Ok)),
@@ -185,10 +185,10 @@ fn test_quarantine() {
         timestamp: std::time::SystemTime::now(),
         skipped: None,
     });
-    *state.message().write().unwrap() = Some(MessageBody::Raw {
+    *state.message().write().unwrap() = MessageBody::Raw {
         headers: vec![],
         body: Some("".to_string()),
-    });
+    };
     assert_eq!(
         re.run_when(&mut state, &StateSMTP::PreQ),
         Status::Accept(ReplyOrCodeID::CodeID(CodeID::Ok)),
@@ -203,14 +203,14 @@ fn test_quarantine() {
         .iter()
         .all(|rcpt| rcpt.transfer_method == Transfer::None));
 
-    *state.message().write().unwrap() = Some(MessageBody::Parsed(Box::new(Mail {
+    *state.message().write().unwrap() = MessageBody::Parsed(Box::new(Mail {
         headers: vec![
             ("From".to_string(), "john@doe.com".to_string()),
             ("To".to_string(), "green@bar.net".to_string()),
             ("X-Custom-Header".to_string(), "my header".to_string()),
         ],
         body: BodyType::Regular(vec!["this is an empty body".to_string()]),
-    })));
+    }));
     assert_eq!(
         re.run_when(&mut state, &StateSMTP::PostQ),
         Status::Quarantine("tests/generated/quarantine2".to_string())
@@ -225,7 +225,7 @@ fn test_forward() {
     )
     .unwrap();
     let (mut state, _) = get_default_state("./tmp/app");
-    *state.message().write().unwrap() = Some(MessageBody::Parsed(Box::new(Mail::default())));
+    *state.message().write().unwrap() = MessageBody::Parsed(Box::new(Mail::default()));
 
     assert_eq!(re.run_when(&mut state, &StateSMTP::Connect), Status::Next);
     assert_eq!(re.run_when(&mut state, &StateSMTP::Delivery), Status::Next);
@@ -296,7 +296,7 @@ fn test_forward_all() {
     )
     .unwrap();
     let (mut state, _) = get_default_state("./tmp/app");
-    *state.message().write().unwrap() = Some(MessageBody::Parsed(Box::new(Mail::default())));
+    *state.message().write().unwrap() = MessageBody::Parsed(Box::new(Mail::default()));
 
     re.run_when(&mut state, &StateSMTP::Connect);
 

--- a/src/vsmtp/vsmtp-rule-engine/src/tests/email/main.vsl
+++ b/src/vsmtp/vsmtp-rule-engine/src/tests/email/main.vsl
@@ -16,19 +16,6 @@
 */
 #{
     connect: [
-        rule "fail mail_from rewrite: email not received" || {
-            try {
-                rewrite_mail_from("impossible@torewrite.com");
-                return deny();
-            } catch (err) {
-                if "the field: `message` is not defined" in err {
-                    return next();
-                } else {
-                    return deny();
-                }
-            }
-        },
-
         rule "fail mail_from rewrite: bad address format" || {
             try {
                 rewrite_mail_from("invalid");

--- a/src/vsmtp/vsmtp-rule-engine/src/tests/email/mod.rs
+++ b/src/vsmtp/vsmtp-rule-engine/src/tests/email/mod.rs
@@ -52,7 +52,7 @@ fn test_email_context_raw() {
             "from: <foo@bar>".to_string(),
             "date: Tue, 30 Nov 2021 20:54:27 +0100".to_string(),
         ],
-        body: "".to_string(),
+        body: Some("".to_string()),
     });
     assert_eq!(
         re.run_when(&mut state, &StateSMTP::PreQ),
@@ -124,7 +124,7 @@ fn test_email_add_get_set_header() {
     let (mut state, _) = get_default_state("./tmp/app");
     *state.message().write().unwrap() = Some(MessageBody::Raw {
         headers: vec![],
-        body: "".to_string(),
+        body: Some("".to_string()),
     });
     let status = re.run_when(&mut state, &StateSMTP::PreQ);
     assert_eq!(status, Status::Accept(ReplyOrCodeID::CodeID(CodeID::Ok)));

--- a/src/vsmtp/vsmtp-rule-engine/src/tests/email/mod.rs
+++ b/src/vsmtp/vsmtp-rule-engine/src/tests/email/mod.rs
@@ -47,13 +47,13 @@ fn test_email_context_raw() {
     let resolvers = std::sync::Arc::new(std::collections::HashMap::new());
     let mut state = RuleState::new(&config, resolvers, &re);
 
-    *state.message().write().unwrap() = Some(MessageBody::Raw {
+    *state.message().write().unwrap() = MessageBody::Raw {
         headers: vec![
             "from: <foo@bar>".to_string(),
             "date: Tue, 30 Nov 2021 20:54:27 +0100".to_string(),
         ],
         body: Some("".to_string()),
-    });
+    };
     assert_eq!(
         re.run_when(&mut state, &StateSMTP::PreQ),
         Status::Accept(ReplyOrCodeID::CodeID(CodeID::Ok)),
@@ -67,13 +67,13 @@ fn test_email_context_mail() {
     let resolvers = std::sync::Arc::new(std::collections::HashMap::new());
     let mut state = RuleState::new(&config, resolvers, &re);
 
-    *state.message().write().unwrap() = Some(MessageBody::Parsed(Box::new(Mail {
+    *state.message().write().unwrap() = MessageBody::Parsed(Box::new(Mail {
         headers: vec![(
             "to".to_string(),
             "other.rcpt@toremove.org, other.rcpt@torewrite.net".to_string(),
         )],
         body: BodyType::Regular(vec![]),
-    })));
+    }));
     state.context().write().unwrap().envelop.rcpt = vec![
         addr!("rcpt@toremove.org").into(),
         addr!("rcpt@torewrite.net").into(),
@@ -85,13 +85,7 @@ fn test_email_context_mail() {
     );
 
     assert_eq!(
-        state
-            .message()
-            .read()
-            .unwrap()
-            .as_ref()
-            .unwrap()
-            .get_header("to"),
+        state.message().read().unwrap().get_header("to"),
         Some("other.new@rcpt.net, other.added@rcpt.com")
     );
 }
@@ -118,21 +112,21 @@ fn test_email_add_get_set_header() {
     let mut state = RuleState::new(&config, resolvers, &re);
     assert_eq!(
         re.run_when(&mut state, &StateSMTP::Connect),
-        Status::Deny(ReplyOrCodeID::CodeID(CodeID::Denied))
+        Status::Accept(ReplyOrCodeID::CodeID(CodeID::Ok))
     );
 
     let (mut state, _) = get_default_state("./tmp/app");
-    *state.message().write().unwrap() = Some(MessageBody::Raw {
+    *state.message().write().unwrap() = MessageBody::Raw {
         headers: vec![],
         body: Some("".to_string()),
-    });
+    };
     let status = re.run_when(&mut state, &StateSMTP::PreQ);
     assert_eq!(status, Status::Accept(ReplyOrCodeID::CodeID(CodeID::Ok)));
 
-    *state.message().write().unwrap() = Some(MessageBody::Parsed(Box::new(Mail {
+    *state.message().write().unwrap() = MessageBody::Parsed(Box::new(Mail {
         headers: vec![],
         body: BodyType::Regular(vec![]),
-    })));
+    }));
 
     state.context().write().unwrap().metadata = Some(MessageMetadata::default());
     assert_eq!(

--- a/src/vsmtp/vsmtp-rule-engine/src/tests/engine/mod.rs
+++ b/src/vsmtp/vsmtp-rule-engine/src/tests/engine/mod.rs
@@ -115,10 +115,10 @@ fn test_rule_state() {
             },
             metadata: None,
         },
-        Some(MessageBody::Raw {
+        MessageBody::Raw {
             headers: vec![],
-            body: Some("".to_string()),
-        }),
+            body: None,
+        },
     );
 
     assert_eq!(

--- a/src/vsmtp/vsmtp-rule-engine/src/tests/engine/mod.rs
+++ b/src/vsmtp/vsmtp-rule-engine/src/tests/engine/mod.rs
@@ -117,7 +117,7 @@ fn test_rule_state() {
         },
         Some(MessageBody::Raw {
             headers: vec![],
-            body: "".to_string(),
+            body: Some("".to_string()),
         }),
     );
 

--- a/src/vsmtp/vsmtp-rule-engine/src/tests/rules.rs
+++ b/src/vsmtp/vsmtp-rule-engine/src/tests/rules.rs
@@ -69,19 +69,17 @@ fn test_mail_from_rules() {
         let message = state.message();
         let mut message = message.write().unwrap();
 
-        *message = Some(
-            MailMimeParser::default()
-                .parse_lines(
-                    r#"From: staff <staff@example.com>
+        *message = MailMimeParser::default()
+            .parse_lines(
+                r#"From: staff <staff@example.com>
 Date: Fri, 21 Nov 1997 10:01:10 -0600
 
 This is a reply to your hello."#
-                        .lines()
-                        .map(str::to_string)
-                        .collect::<Vec<_>>(),
-                )
-                .unwrap(),
-        );
+                    .lines()
+                    .map(str::to_string)
+                    .collect::<Vec<_>>(),
+            )
+            .unwrap();
     }
 
     assert_eq!(
@@ -120,19 +118,17 @@ fn test_rcpt_rules() {
         let message = state.message();
         let mut message = message.write().unwrap();
 
-        *message = Some(
-            MailMimeParser::default()
-                .parse_lines(
-                    r#"From: staff <staff@example.com>
+        *message = MailMimeParser::default()
+            .parse_lines(
+                r#"From: staff <staff@example.com>
 Date: Fri, 21 Nov 1997 10:01:10 -0600
 
 This is a reply to your hello."#
-                        .lines()
-                        .map(str::to_string)
-                        .collect::<Vec<_>>(),
-                )
-                .unwrap(),
-        );
+                    .lines()
+                    .map(str::to_string)
+                    .collect::<Vec<_>>(),
+            )
+            .unwrap();
     }
 
     assert_eq!(

--- a/src/vsmtp/vsmtp-rule-engine/src/tests/types/mod.rs
+++ b/src/vsmtp/vsmtp-rule-engine/src/tests/types/mod.rs
@@ -124,7 +124,7 @@ fn test_services() {
 
     *state.message().write().unwrap() = Some(MessageBody::Raw {
         headers: vec![],
-        body: "".to_string(),
+        body: Some("".to_string()),
     });
 
     assert_eq!(
@@ -177,7 +177,7 @@ fn test_config_display() {
 
     *state.message().write().unwrap() = Some(MessageBody::Raw {
         headers: vec![],
-        body: "".to_string(),
+        body: Some("".to_string()),
     });
 
     assert_eq!(

--- a/src/vsmtp/vsmtp-rule-engine/src/tests/types/mod.rs
+++ b/src/vsmtp/vsmtp-rule-engine/src/tests/types/mod.rs
@@ -122,10 +122,10 @@ fn test_services() {
     let resolvers = std::sync::Arc::new(std::collections::HashMap::new());
     let mut state = RuleState::new(&config, resolvers, &re);
 
-    *state.message().write().unwrap() = Some(MessageBody::Raw {
+    *state.message().write().unwrap() = MessageBody::Raw {
         headers: vec![],
         body: Some("".to_string()),
-    });
+    };
 
     assert_eq!(
         re.run_when(&mut state, &StateSMTP::Connect),
@@ -175,10 +175,10 @@ fn test_config_display() {
     let resolvers = std::sync::Arc::new(std::collections::HashMap::new());
     let mut state = RuleState::new(&config, resolvers, &re);
 
-    *state.message().write().unwrap() = Some(MessageBody::Raw {
+    *state.message().write().unwrap() = MessageBody::Raw {
         headers: vec![],
         body: Some("".to_string()),
-    });
+    };
 
     assert_eq!(
         re.run_when(&mut state, &StateSMTP::Helo),

--- a/src/vsmtp/vsmtp-server/src/delivery/deferred.rs
+++ b/src/vsmtp/vsmtp-server/src/delivery/deferred.rs
@@ -189,7 +189,7 @@ mod tests {
             "test_deferred",
             &MessageBody::Raw {
                 headers: vec!["Date: bar".to_string(), "From: foo".to_string()],
-                body: "Hello world".to_string(),
+                body: Some("Hello world".to_string()),
             },
         )
         .unwrap();
@@ -247,7 +247,7 @@ mod tests {
             message_from_file_path(msg).await.unwrap(),
             MessageBody::Raw {
                 headers: vec!["Date: bar".to_string(), "From: foo".to_string(),],
-                body: "Hello world".to_string(),
+                body: Some("Hello world".to_string()),
             }
         );
     }

--- a/src/vsmtp/vsmtp-server/src/delivery/deliver.rs
+++ b/src/vsmtp/vsmtp-server/src/delivery/deliver.rs
@@ -267,7 +267,7 @@ mod tests {
             "message_from_deliver_to_deferred",
             &MessageBody::Raw {
                 headers: vec!["Date: bar".to_string(), "From: foo".to_string()],
-                body: "Hello world".to_string(),
+                body: Some("Hello world".to_string()),
             },
         )
         .unwrap();

--- a/src/vsmtp/vsmtp-server/src/delivery/deliver.rs
+++ b/src/vsmtp/vsmtp-server/src/delivery/deliver.rs
@@ -130,7 +130,7 @@ async fn handle_one_in_delivery_queue_inner(
 
     let mail_message = message_from_file_path(message_filepath).await?;
 
-    let (mut mail_context, mail_message, result) = RuleState::just_run_when(
+    let (mut mail_context, mut mail_message, result) = RuleState::just_run_when(
         &StateSMTP::Delivery,
         config.as_ref(),
         resolvers.clone(),
@@ -139,9 +139,7 @@ async fn handle_one_in_delivery_queue_inner(
         mail_message,
     )?;
 
-    let mut message = mail_message.ok_or_else(|| anyhow::anyhow!("message is empty"))?;
-
-    add_trace_information(&config, &mut mail_context, &mut message, &result)?;
+    add_trace_information(&config, &mut mail_context, &mut mail_message, &result)?;
 
     match result {
         Status::Quarantine(path) => {
@@ -165,7 +163,7 @@ async fn handle_one_in_delivery_queue_inner(
             Queue::Dead.write_to_queue(&config.server.queues.dirpath, &mail_context)?;
         }
         _ => {
-            send_mail(&config, &mut mail_context, &message, &resolvers).await;
+            send_mail(&config, &mut mail_context, &mail_message, &resolvers).await;
             // .context(format!(
             //     "failed to send '{}' located in the delivery queue",
             //     process_message.message_id

--- a/src/vsmtp/vsmtp-server/src/delivery/mod.rs
+++ b/src/vsmtp/vsmtp-server/src/delivery/mod.rs
@@ -352,7 +352,7 @@ mod test {
 
         let mut message = MessageBody::Raw {
             headers: vec![],
-            body: "".to_string(),
+            body: Some("".to_string()),
         };
         ctx.metadata.as_mut().unwrap().message_id = "test_message_id".to_string();
         add_trace_information(&config, &mut ctx, &mut message, &Status::Next).unwrap();
@@ -380,7 +380,7 @@ mod test {
                     ]
                     .concat(),
                 ],
-                body: "".to_string(),
+                body: Some("".to_string()),
             }
         );
     }

--- a/src/vsmtp/vsmtp-server/src/lib.rs
+++ b/src/vsmtp/vsmtp-server/src/lib.rs
@@ -91,7 +91,7 @@ pub async fn message_from_file_path(
 
         return Ok(MessageBody::Raw {
             headers: headers.lines().map(str::to_string).collect(),
-            body: body.to_string(),
+            body: Some(body.to_string()),
         });
     }
     anyhow::bail!("failed does not exist")

--- a/src/vsmtp/vsmtp-server/src/processing/mod.rs
+++ b/src/vsmtp/vsmtp-server/src/processing/mod.rs
@@ -298,7 +298,7 @@ mod tests {
             "test",
             &MessageBody::Raw {
                 headers: vec!["Date: bar".to_string(), "From: foo".to_string()],
-                body: "Hello world".to_string(),
+                body: Some("Hello world".to_string()),
             },
         )
         .unwrap();
@@ -381,7 +381,7 @@ mod tests {
             "test_denied",
             &MessageBody::Raw {
                 headers: vec!["Date: bar".to_string(), "From: foo".to_string()],
-                body: "Hello world".to_string(),
+                body: Some("Hello world".to_string()),
             },
         )
         .unwrap();

--- a/src/vsmtp/vsmtp-server/src/processing/mod.rs
+++ b/src/vsmtp/vsmtp-server/src/processing/mod.rs
@@ -143,7 +143,7 @@ async fn handle_one_in_working_queue_inner(
     Queue::write_to_mails(
         &config.server.queues.dirpath,
         &process_message.message_id,
-        &message.ok_or_else(|| anyhow::anyhow!("message is empty"))?,
+        &message,
     )?;
 
     let queue = match result {

--- a/src/vsmtp/vsmtp-server/src/receiver/mod.rs
+++ b/src/vsmtp/vsmtp-server/src/receiver/mod.rs
@@ -156,13 +156,20 @@ where
     S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Send + Unpin + Sync,
     M: OnMail + Send,
 {
-    let body = {
+    let mut body = {
         let stream = Transaction::stream(conn);
         tokio::pin!(stream);
         NoParsing::default().parse(stream).await?
     };
 
-    *transaction.rule_state.message().write().unwrap() = Some(body);
+    {
+        let handle = transaction.rule_state.message();
+        let mut message = handle.write().unwrap();
+
+        // headers could have been added to the email before preq.
+        body.extend_raw_headers(&*message);
+        *message = body;
+    }
 
     let status = transaction
         .rule_engine
@@ -193,7 +200,7 @@ where
 
     let helo = mail_context.envelop.helo.clone();
     let code = mail_handler
-        .on_mail(conn, Box::new(mail_context), message.unwrap())
+        .on_mail(conn, Box::new(mail_context), message)
         .await;
     *helo_domain = Some(helo);
     conn.send_code(code).await?;

--- a/src/vsmtp/vsmtp-server/src/receiver/mod.rs
+++ b/src/vsmtp/vsmtp-server/src/receiver/mod.rs
@@ -139,7 +139,10 @@ impl MailParserOnFly for NoParsing {
             body.push_str("\r\n");
         }
 
-        Ok(MessageBody::Raw { headers, body })
+        Ok(MessageBody::Raw {
+            headers,
+            body: Some(body),
+        })
     }
 }
 

--- a/src/vsmtp/vsmtp-server/src/receiver/transaction.rs
+++ b/src/vsmtp/vsmtp-server/src/receiver/transaction.rs
@@ -21,7 +21,7 @@ use vsmtp_common::{
     auth::Mechanism,
     envelop::Envelop,
     event::Event,
-    mail_context::{ConnectionContext, MessageMetadata},
+    mail_context::{ConnectionContext, MessageBody, MessageMetadata},
     rcpt::Rcpt,
     re::{anyhow, log, tokio},
     state::StateSMTP,
@@ -99,7 +99,7 @@ impl Transaction {
                 }
                 {
                     let state = self.rule_state.message();
-                    *state.write().unwrap() = None;
+                    *state.write().unwrap() = MessageBody::default();
                 }
 
                 ProcessedEvent::ReplyChangeState(StateSMTP::Helo, ReplyOrCodeID::CodeID(CodeID::Ok))
@@ -304,7 +304,7 @@ impl Transaction {
         }
         {
             let state = self.rule_state.message();
-            *state.write().unwrap() = None;
+            *state.write().unwrap() = MessageBody::default();
         }
     }
 
@@ -347,7 +347,7 @@ impl Transaction {
         }
         {
             let state = self.rule_state.message();
-            *state.write().unwrap() = None;
+            *state.write().unwrap() = MessageBody::default();
         }
     }
 

--- a/src/vsmtp/vsmtp-test/src/tests/rules/quarantine/mod.rs
+++ b/src/vsmtp/vsmtp-test/src/tests/rules/quarantine/mod.rs
@@ -81,7 +81,7 @@ async fn test_quarantine() {
         message_from_file_path(path).await.unwrap(),
         MessageBody::Raw {
             headers: vec!["from: 'abc'".to_string(), "to: 'def'".to_string()],
-            body: "".to_string()
+            body: Some("".to_string())
         }
     );
 }


### PR DESCRIPTION
## Changed
- The `MessageBody` struct is no longer wrapped in an `Option`, enabling the user to add any header to the email before the `preq` stage.

```rust
#{
   // email has not been received yet, but we can add headers anyway.
   // this is useful, for example, the SPF protocol.
    mail: [
        action "setup headers" || {
            append_header("X-VSMTP-1", "...");
            prepend_header("X-VSMTP-2", "...");
        },
    ],
}
```