### PR TITLE
Anti relaying

### DIFF
--- a/examples/vsl/actions/utils.vsl
+++ b/examples/vsl/actions/utils.vsl
@@ -2,7 +2,7 @@
     connect: [
         rule "check root domain" || {
             if in_domain(sys::new_address("rcpt@testserver.com"))
-            && in_domain("rcpt@testserver.com")
+            && in_domain("testserver.com")
             && ctx().server_name == "testserver.com" {
                 accept()
             } else {
@@ -16,7 +16,7 @@
             print(toml::server.virtual);
             if in_domain(sys::new_address("rcpt@example.com")) == true
             && in_domain(sys::new_address("john@unknown.com")) == false
-            && in_domain("john@unknown.com") == false
+            && in_domain("unknown.com") == false
             && in_domain("invalid") == false {
                 accept()
             } else {

--- a/examples/vsl/anti_relaying/main.vsl
+++ b/examples/vsl/anti_relaying/main.vsl
@@ -1,11 +1,17 @@
 import "net" as net;
 
 #{
+    mail: [
+        // checking if the mail from domain can be found
+        // in our domain / sni configuration.
+        // in case of a relaying tentative, `check_relay`
+        // will send a 554 error code to the client.
+	    rule "check mail relay" || check_mail_relay(net::allowed_hosts),
+    ],
+
     rcpt: [
         // checking if all recipients domains can be found
         // in our configuration.
-        // in case of a relaying tentative, `check_relay`
-        // will send a 554 error code to the client.
-	    rule "check relay" || check_relay(net::custom_authorized),
+	    rule "check rcpt relay" || check_rcpt_relay(net::allowed_hosts),
     ],
 }

--- a/examples/vsl/anti_relaying/net.vsl
+++ b/examples/vsl/anti_relaying/net.vsl
@@ -1,6 +1,4 @@
-object custom_authorized group = [
-    object a ip4 = "192.158.1.1",
-    object b ip4 = "192.158.1.2",
-    object c ip4 = "192.158.1.3",
-    object d ip4 = "192.158.1.4",
+object allowed_hosts group = [
+    object my_server ip4 = "192.168.1.254",
+    object my_secondary_mta fqdn = "mta-internal.foobar.com",
 ];

--- a/src/vsmtp/vsmtp-rule-engine/src/api/auth.rhai
+++ b/src/vsmtp/vsmtp-rule-engine/src/api/auth.rhai
@@ -42,11 +42,10 @@
 ///    }        
 /// ]
 fn check_mail_relay(allowed_hosts) {
-    if in_domain(ctx().mail_from.domain) 
-       && !(ctx().is_authenticated || (ctx().client_ip in allowed_hosts)) {
-        return deny(code554_7_1);
-    }
-    else { 
+    if in_domain(ctx().mail_from)
+    && !(ctx().is_authenticated || (ctx().client_ip in allowed_hosts)) {
+        deny(code554_7_1)
+    } else {
         next()
     }    
 }
@@ -74,12 +73,11 @@ fn check_mail_relay(allowed_hosts) {
 ///    }        
 /// ]
 fn check_rcpt_relay(allowed_hosts) {
-    if !in_domain(ctx().rcpt) 
-       && !(ctx().is_authenticated || (ctx().client_ip in allowed_hosts)) {
-        remove_rcpt(rcpt.to_string());
-        return deny(code554_7_1);
-    }
-    else { 
+    if !in_domain(ctx().rcpt)
+    && !(ctx().is_authenticated || (ctx().client_ip in allowed_hosts)) {
+        remove_rcpt(ctx().rcpt.to_string());
+        deny(code554_7_1)
+    } else {
         next()
     }    
 }

--- a/src/vsmtp/vsmtp-rule-engine/src/api/auth.rhai
+++ b/src/vsmtp/vsmtp-rule-engine/src/api/auth.rhai
@@ -19,35 +19,69 @@
 // standard library for authentication
 //
 
-/// Block relaying. Inspect all recipients domains & check if those are registered in the
-/// root domain or virtual ones.
+/// check "mail from" relaying.
+/// Do not accept a msg from a known internal domain if the client is unknown 
 ///
-/// The check is skipped if the client is authenticated or if it's api is present in the
-/// `allowed_host` parameter.
+/// # Args
+/// @allowed_hosts: group of (IPv4 | IPv6 | IPv4 range | IPv6 range | fqdn)
 ///
-/// NOTE: you can use this function starting from the `rcpt` stage.
+/// # Return
+/// - deny() or next()
 ///
-/// # Returns
-///   * `next` if all recipients are valid.
-///   * `deny(554)` if any recipient tries to use the server as a relay.
+/// # Required stage : mail (only)
 ///
-/// ### Example
+/// # Example 
+/// ```
+/// mail: [
+///    rule "check mail relay" || {
+///        object allowed_hosts group = [
+///            object ip4 "192.168.1.254",
+///            object fqdn "mta-internal.foobar.com"
+///        ];
+///        check_mail_relay(allowed_hosts);
+///    }        
+/// ]
+fn check_mail_relay(allowed_hosts) {
+    if in_domain(ctx().mail_from.domain) 
+       && !(ctx().is_authenticated || (ctx().client_ip in allowed_hosts)) {
+        return deny(code554_7_1);
+    }
+    else { 
+        next()
+    }    
+}
+
+/// check "rcpt to" relaying.
+/// Do not accept open relaying
+///
+/// # Args
+/// @allowed_hosts: group of (IPv4 | IPv6 | IPv4 range | IPv6 range | fqdn)
+///
+/// # Return
+/// - deny() or next()
+///
+/// # Required stage : rcpt (only)
+///
+/// # Example 
 /// ```
 /// rcpt: [
-///     rule "check relay" || vsl::check_relay(net_192)
+///    rule "check rcpt relay" || {
+///        object allowed_hosts group = [
+///            object ip4 "192.168.1.254",
+///            object fqdn "mta-internal.foobar.com"
+///        ];
+///        check_rcpt_relay(allowed_hosts);
+///    }        
 /// ]
-/// ```
-///
-fn check_relay(allowed_hosts) {
-    for rcpt in ctx().rcpt_list {
-        if !(ctx().is_authenticated || (ctx().client_ip in allowed_hosts))
-            && !in_domain(rcpt) {
-                remove_rcpt(rcpt.to_string());
-                return deny(code554_7_1);
-        }
+fn check_rcpt_relay(allowed_hosts) {
+    if !in_domain(ctx().rcpt) 
+       && !(ctx().is_authenticated || (ctx().client_ip in allowed_hosts)) {
+        remove_rcpt(rcpt.to_string());
+        return deny(code554_7_1);
     }
-
-    next()
+    else { 
+        next()
+    }    
 }
 
 /// check spf record.

--- a/src/vsmtp/vsmtp-rule-engine/src/api/utils.rhai
+++ b/src/vsmtp/vsmtp-rule-engine/src/api/utils.rhai
@@ -21,8 +21,7 @@ private fn __in_domain(rcpt) {
             rcpt.domain in toml::server.virtual || rcpt.domain == toml::server.domain
         },
         "string" => {
-            // converting to an address could fail.
-            try { return __in_domain(sys::new_address(rcpt)); } catch { return false; }
+            rcpt in toml::server.virtual || rcpt == toml::server.domain
         },
         _ => false,
     }

--- a/src/vsmtp/vsmtp-rule-engine/src/tests/integrations.rs
+++ b/src/vsmtp/vsmtp-rule-engine/src/tests/integrations.rs
@@ -55,7 +55,24 @@ fn test_greylist() {
 fn test_check_relay() {
     let config = get_default_config("./tmp/app");
     let re = RuleEngine::new(&config, &Some(root_example!["anti_relaying/main.vsl"])).unwrap();
+
     let resolvers = std::sync::Arc::new(std::collections::HashMap::new());
+    let mut state = RuleState::new(&config, resolvers.clone(), &re);
+
+    // using our domain but the sender isn't identified.
+    state.context().write().unwrap().envelop.mail_from = addr!("satan@testserver.com");
+
+    assert_eq!(
+        re.run_when(&mut state, &StateSMTP::MailFrom),
+        Status::Deny(ReplyOrCodeID::Reply(Reply::new(
+            Enhanced {
+                code: 554,
+                enhanced: "5.7.1".to_string()
+            },
+            "Relay access denied"
+        )))
+    );
+
     let mut state = RuleState::new(&config, resolvers.clone(), &re);
 
     state


### PR DESCRIPTION
## Changed
- `check_relay` function has been changed to:
  - `check_mail_relay` to check an attempt from the sender to use our identity without being identified.
  - `check_rcpt_relay` to check if the current recipient's domain is equal to our root domain and/or sni configured in the toml file.

```rust
import "my_net" as net;

#{
    mail: [
        // checking if the mail from domain can be found
        // in our domain / sni configuration.
        // in case of a relaying tentative, `check_relay`
        // will send a 554 error code to the client.
	rule "check mail relay" || check_mail_relay(net::allowed_hosts),
    ],

    rcpt: [
        // checking if all recipients domains can be found
        // in our configuration.
	rule "check rcpt relay" || check_rcpt_relay(net::allowed_hosts),
    ],
}
```