### PR TITLE
Refactoring Spf

### DIFF
--- a/examples/config/auth/main.vsl
+++ b/examples/config/auth/main.vsl
@@ -3,7 +3,7 @@
         rule "auth /etc/shadow" || {
             switch ctx().auth.type {
                 "Verify" => {
-                    let result = srv().run_service(ctx, "saslauthd");
+                    let result = srv().run_service(ctx(), "saslauthd");
 
                     if result.has_signal {
                         // timed out

--- a/src/vsmtp/vsmtp-rule-engine/src/api/auth.rhai
+++ b/src/vsmtp/vsmtp-rule-engine/src/api/auth.rhai
@@ -120,7 +120,7 @@ fn auth_header(query) {
 /// Sender Policy Framework (RFC 7208).
 ///
 /// # Args
-/// @identity: "helo" | "mail_from" | "both"
+/// @identity: "helo" | "mail_from"
 /// @header: "spf" | "auth" | "both" | "none"
 /// @policy: "strict" | "soft"
 ///
@@ -153,7 +153,8 @@ fn check_spf(identity, header, policy) {
             prepend_header(AUTH_HEADER, auth_header(query));
             prepend_header(SPF_HEADER, spf_header(query));
         },
-        _ => {},
+        "none" => {},
+        _ => throw `spf 'header' argument must be 'spf', 'auth' or 'both', not '${header}'`,
     }
 
     if policy == "strict" {


### PR DESCRIPTION
## Changed
- remove the "both" identity parameter for spf.
- "mail" identity parameter only checks for mail identity, "helo" check for helo identity and falls back to "mail" identity.
- `check_spf` does not throw errors on spf error, only return `result: none`. (it can throw errors if parameters are not right though)