### PR TITLE
SPF in domain

### DIFF
--- a/src/vsmtp/vsmtp-rule-engine/src/api/auth.rhai
+++ b/src/vsmtp/vsmtp-rule-engine/src/api/auth.rhai
@@ -137,6 +137,10 @@ fn auth_header(query) {
 /// ```
 fn check_spf(header, policy) {
 
+    if in_domain(ctx().mail_from) {
+        return next();
+    }
+
     const AUTH_HEADER = "Authentication-Results";
     const SPF_HEADER = "Received-SPF";
 


### PR DESCRIPTION
## Changed
- If the mail from domain is within the server's domain, then no spf check is made.