### PR TITLE
Release 1.1.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ repository = "https://github.com/viridIT/vSMTP"
 documentation = "https://docs.rs/crate/vsmtp/"
 
 readme = "README.md"
-keywords = ["vsmtp", "mta", "smtp", "server", "mail", "greenhouse"]
+keywords = ["vsmtp", "mta", "smtp", "server", "mail"]
 categories = ["email"]
 
 rust-version = "1.58"


### PR DESCRIPTION
Remove a keyword in the `vsmtp` crate to enable pushing to `crate.io`.