### PR TITLE
disabling dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,9 @@
-version: 2
-updates:
-  - package-ecosystem: cargo
-    directory: "/"
-    schedule:
-      interval: daily
-    labels:
-      - "A-dependencies"
-    open-pull-requests-limit: 10
+# version: 2
+# updates:
+#   - package-ecosystem: cargo
+#     directory: "/"
+#     schedule:
+#       interval: daily
+#     labels:
+#       - "A-dependencies"
+#     open-pull-requests-limit: 10


### PR DESCRIPTION
Since we are in the process of packaging vsmtp for Debian, all dependencies versions needs to be frozen.