### PR TITLE
Add Docker Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ release. They will however *never* happen in a patch release.
 
 ### Added
 
+* Support Docker (#340)
 * support for `MySQL` databases. see [`/examples/greylist/mysql`](https://github.com/viridIT/vSMTP/tree/develop/examples/greylist/mysql). (#548)
 
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM rust:1-alpine3.16 AS dependencies
+RUN apk add libgsasl clang gcc musl-dev
+
+FROM dependencies AS build
+COPY . .
+RUN cargo test
+RUN cargo build --release
+
+FROM build
+WORKDIR /root/
+COPY --from=build target/release/vsmtp .
+ENTRYPOINT [ "./vsmtp" ]

--- a/tools/install/deb/changelog
+++ b/tools/install/deb/changelog
@@ -1,7 +1,8 @@
 vsmtp (1.3.0-rc.0) UNRELEASED; urgency=low
 
-  [ Updated by mlala ]
+  [ Updated by mlala and pantsman0]
   * Added
+    - Supprt Docker (#340)
     - support for `MySQL` databases. see `/examples/greylist/mysql`. (#548)
   * Changed
     - update the backend of the `SASL` protocol, using a state-of-the-art Rust


### PR DESCRIPTION
## Requirements

- [X] I have read the `CODE_OF_CONDUCT.md`.
- [X] I have updated `CHANGELOG.md` & `tools/install/deb/changelog` to reflect my changes.

## Motivation
Address #340. This can then be used with github's https://github.com/marketplace/actions/build-and-push-docker-images to automatically deploy images to docker hub.

## Solution

### Changed
- Changelogs

### Added
- Added Initial Dockerfile
