### PR TITLE
treewide: set GIT_HASH to unknown if `git rev-parse HEAD` fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ release. They will however *never* happen in a patch release.
 ### Fixed
 
 - Display proper configuration error messages on machine that do not have a 'vsmtp' user (#926)
+- Building without `.git` no longer causes a hard failure
 
 ## [2.0.0] - 2023-01-09
 

--- a/src/vqueue/build.rs
+++ b/src/vqueue/build.rs
@@ -20,10 +20,10 @@ fn main() {
     let output = Command::new("git")
         .args(["rev-parse", "HEAD"])
         .output()
-        .expect("failed to get git commit hash");
+        .map(|out| out.stdout).unwrap_or("unknown".as_bytes().to_vec());
 
     println!(
         "cargo:rustc-env=GIT_HASH={}",
-        String::from_utf8(output.stdout).expect("failed to convert hash to valid utf8")
+        String::from_utf8(output).expect("failed to convert hash to valid utf8")
     );
 }

--- a/src/vsmtp/vsmtp-core/build.rs
+++ b/src/vsmtp/vsmtp-core/build.rs
@@ -21,11 +21,11 @@ fn main() {
     let output = Command::new("git")
         .args(["rev-parse", "HEAD"])
         .output()
-        .expect("failed to get git commit hash");
+        .map(|out| out.stdout).unwrap_or("unknown".as_bytes().to_vec());
 
     println!(
         "cargo:rustc-env=GIT_HASH={}",
-        String::from_utf8(output.stdout).expect("failed to convert hash to valid utf8")
+        String::from_utf8(output).expect("failed to convert hash to valid utf8")
     );
 
     if std::env::var("DOCS_DIR").is_ok() {

--- a/tools/install/deb/changelog
+++ b/tools/install/deb/changelog
@@ -4,6 +4,7 @@ vsmtp (x.y.z) UNRELEASED; urgency=low
 
 * Fixed
   * Display proper configuration errors. (#926)
+  * Building without `.git` no longer causes a hard failure
 
  -- ltabis <l.tabis@viridit.com>  Mon, 09 Jan 2023 21:52:36 +0100
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests !

Contributors guide: https://github.com/viridIT/vSMTP/blob/main/CONTRIBUTING.md
-->

## Requirements

<!--
Be sure to tick everything before submitting your PR !
-->

- [x] I have read the `CODE_OF_CONDUCT.md`.
- [x] I have updated `CHANGELOG.md` & `tools/install/deb/changelog` to reflect my changes.

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->
Currently building from the release tarball causes a hard failure, as `.git` is not available for embedding the version information.
## Solution
In stead of bailing out, mark the version as unknown.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.

You can class you changes with the following sub-titles (using ###):
- Fixed   (You fixed a bug)
- Changed (You changed something existing, possibly making breaking changes)
- Added   (You added something new)
- Other   (You did something else)

Example:
```markdown
### Changed
- Changed the way the server handles connections.

### Added
- Added a new command to the server.
- Added stuff to the documentation.
```
-->
